### PR TITLE
fix getLastValue when array key doesnt exist

### DIFF
--- a/src/Result/StateTrackerItem.php
+++ b/src/Result/StateTrackerItem.php
@@ -201,7 +201,7 @@ class StateTrackerItem
     {
         $variables = $this->variables[$name] ?? [];
 
-        return $variables[$name][count($variables[$name]) - 1] ?? null;
+        return $variables[count($variables) - 1] ?? null;
     }
 
     public function get(string $name): ?TypeContract


### PR DESCRIPTION
To stop throwing this error when the StateTrackerItem@variable[name] is not defined.

<img width="1618" height="309" alt="image" src="https://github.com/user-attachments/assets/7d3c2452-4175-4a99-87c8-e218ef0ed87b" />
