### PR TITLE
Fix deprecation notice in `Include_`

### DIFF
--- a/src/NodeResolvers/Expr/Include_.php
+++ b/src/NodeResolvers/Expr/Include_.php
@@ -20,7 +20,7 @@ class Include_ extends AbstractResolver
             return Type::mixed();
         }
 
-        if (! file_exists($result->value)) {
+        if (is_null($result->value) || ! file_exists($result->value)) {
             return Type::mixed();
         }
 


### PR DESCRIPTION
To resolve deprecation notice when passing `null` to `file_exists()`.

<img width="1559" height="455" alt="image" src="https://github.com/user-attachments/assets/ca01a837-1afa-4788-97b8-f03ac59b4976" />
