### PR TITLE
Fix unkeyed array dim assignments not returning a type/value

### DIFF
--- a/src/NodeResolvers/Shared/ResolvesAssigns.php
+++ b/src/NodeResolvers/Shared/ResolvesAssigns.php
@@ -104,6 +104,7 @@ trait ResolvesAssigns
 
         $dim = $dimFetch->dim === null ? Type::int() : $this->from($dimFetch->dim);
         $validDim = Type::is($dim, StringType::class, IntType::class) && $dim->value !== null;
+        $result = $this->from($node->expr);
 
         if ($validDim) {
             [$varToLookFor, $keys] = $this->resolveArrayVarAndKeys($dimFetch);
@@ -111,9 +112,11 @@ trait ResolvesAssigns
             $this->scope->state()->updateArrayKey(
                 $varToLookFor,
                 $keys,
-                $this->from($node->expr),
+                $result,
                 $node,
             );
         }
+        
+        return $result;
     }
 }

--- a/tests/Unit/AssignResolverTest.php
+++ b/tests/Unit/AssignResolverTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Laravel\Surveyor\Analyzer\AnalyzedCache;
+use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Types\IntType;
+
+uses()->group('integration');
+
+beforeEach(function () {
+    AnalyzedCache::clear();
+});
+
+afterEach(function () {
+    AnalyzedCache::clear();
+});
+
+describe('array dim', function () {
+    it('resolves array dim assignments', function () {
+        $fixture = createPhpFixture('
+namespace App;
+
+class ArrayDimAssignTest
+{
+    public function test()
+    {
+        $a = [];
+        
+        return $a[] = 1;
+    }
+}
+');
+        
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+        
+        $method = $result->getMethod('test');
+        $returnType = $method->returnType();
+        
+        expect($returnType)->toBeInstanceOf(IntType::class);
+        expect($returnType->value)->toBe(1);
+    });
+});


### PR DESCRIPTION
Given this piece of code:

```php
class Foo
{
    public function bar() {
        $items = [];

        return $items[] = 1;
    }
}
```

Surveyor currently reports the inferred return type as `mixed`, when it should be an `int` since the RHS of an assignment is the result of the expression.

> I've also noticed that array types do not get updated post-append, only for fixed key assignments but I'll address that in a separate PR.