### PR TITLE
Ignore functions & constants in resolveClassInternal

### DIFF
--- a/src/Support/Util.php
+++ b/src/Support/Util.php
@@ -43,7 +43,9 @@ class Util
 
     protected static function resolveClassInternal(string $value): string
     {
-        if (! self::isClassOrInterface($value)) {
+        // Only attempt Reflection on actual classes/interfaces/traits/enums.
+        // Do not treat functions or defined constants (e.g. `true`, `false`) as classes.
+        if (! (class_exists($value) || interface_exists($value) || trait_exists($value) || enum_exists($value))) {
             return $value;
         }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In PHP 8.2+, code can declare literal boolean return types, e.g.:
```
public function before(): true { return true; }
```

During analysis, Surveyor may propagate the literal token ``"true"`` into ``Types\ClassType``, which calls ``Support\Util::resolveClass()`` → ``resolveClassInternal()``.

Should Surveyor attempt a ``new ReflectionClass($value)`` without first ensuring $value is actually a class-like. For "true", that results in: ``ReflectionException: Class "true" does not exist`` preventing TypeScript generation.

This is resolved by adding a stricter guard to only reflect when $value is a real class/interface/trait/enum:
```
if (! (class_exists($value) || interface_exists($value) || trait_exists($value) || enum_exists($value))) {
    return $value;
}
```

There is an associated PR for Wayfinder: https://github.com/laravel/wayfinder/pull/169