### PR TITLE
Fix isClassOrInterface for PHP built-in constants

### DIFF
--- a/src/Support/Util.php
+++ b/src/Support/Util.php
@@ -12,14 +12,31 @@ class Util
 
     protected static array $isClassOrInterface = [];
 
+    /**
+     * PHP built-in constants that should never be treated as class/interface names.
+     */
+    protected static array $builtInConstants = [
+        'null', 'true', 'false', 'inf', 'nan',
+        'php_int_max', 'php_int_min', 'php_int_size',
+        'php_float_max', 'php_float_min', 'php_float_dig', 'php_float_epsilon', 'php_float_inf', 'php_float_nan',
+        'php_eol', 'php_maxpathlen', 'php_os', 'php_os_family',
+        'php_sapi', 'php_major_version', 'php_minor_version', 'php_release_version', 'php_version', 'php_version_id',
+        'directory_separator', 'path_separator',
+        'stdin', 'stdout', 'stderr',
+    ];
+
     public static function isClassOrInterface(string $value): bool
     {
         // Check function_exists() and defined() before class_exists() to prevent
         // the class autoloader from being triggered for namespaced functions that
         // were already loaded via Composer's "autoload.files", which would cause
         // a fatal "cannot redeclare function" error.
+        //
+        // We must exclude PHP built-in constants (NULL, TRUE, FALSE, INF, etc.)
+        // from the defined() check, as they are not classes and would cause
+        // ReflectionClass to throw when used downstream.
         return self::$isClassOrInterface[$value] ??= function_exists($value)
-            || defined($value)
+            || (defined($value) && ! in_array(strtolower($value), self::$builtInConstants, true))
             || class_exists($value)
             || interface_exists($value)
             || trait_exists($value)
@@ -53,7 +70,11 @@ class Util
             return $value;
         }
 
-        $reflection = new ReflectionClass($value);
+        try {
+            $reflection = new ReflectionClass($value);
+        } catch (\ReflectionException) {
+            return $value;
+        }
 
         if ($reflection->isSubclassOf(Facade::class)) {
             return ltrim(get_class($value::getFacadeRoot()), '\\');

--- a/tests/Unit/UtilTest.php
+++ b/tests/Unit/UtilTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Laravel\Surveyor\Support\Util;
+
+describe('Util::isClassOrInterface', function () {
+    it('returns false for PHP built-in constants', function (string $constant) {
+        expect(Util::isClassOrInterface($constant))->toBeFalse();
+    })->with([
+        'NULL',
+        'TRUE',
+        'FALSE',
+        'INF',
+        'NAN',
+        'null',
+        'true',
+        'false',
+        'PHP_INT_MAX',
+        'PHP_EOL',
+        'DIRECTORY_SEPARATOR',
+        'STDIN',
+    ]);
+
+    it('returns true for real classes', function () {
+        expect(Util::isClassOrInterface(\stdClass::class))->toBeTrue();
+        expect(Util::isClassOrInterface(\Iterator::class))->toBeTrue();
+    });
+});
+
+describe('Util::resolveClass', function () {
+    it('returns the value unchanged for PHP built-in constants', function (string $constant) {
+        expect(Util::resolveClass($constant))->toBe($constant);
+    })->with([
+        'NULL',
+        'TRUE',
+        'FALSE',
+    ]);
+
+    it('does not throw ReflectionException for non-existent classes', function () {
+        expect(Util::resolveClass('NonExistentClassName'))->toBe('NonExistentClassName');
+    });
+});


### PR DESCRIPTION
## Summary

- Fixes `Util::isClassOrInterface()` returning `true` for PHP built-in constants (`NULL`, `TRUE`, `FALSE`, `INF`, `NAN`, etc.) because `defined()` matches them, even though they are not classes
- Adds a blocklist of known PHP built-in constants (compared case-insensitively) to exclude from the `defined()` check
- Adds a defensive try-catch around `new ReflectionClass()` in `resolveClassInternal()` as a safety net for any edge cases
- Adds unit tests covering both `isClassOrInterface` and `resolveClass` with built-in constants

Fixes #25

## Test plan

- [x] New test: `isClassOrInterface` returns `false` for `NULL`, `TRUE`, `FALSE`, `INF`, `NAN`, `PHP_INT_MAX`, `PHP_EOL`, `DIRECTORY_SEPARATOR`, `STDIN` (both cases)
- [x] New test: `isClassOrInterface` still returns `true` for real classes (`stdClass`, `Iterator`)
- [x] New test: `resolveClass` returns the value unchanged for `NULL`, `TRUE`, `FALSE`
- [x] New test: `resolveClass` does not throw `ReflectionException` for non-existent class names
- [x] Full test suite passes (197 passed, 1 pre-existing failure in `AnalyzedCacheTest` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)