### PR TITLE
Handle inline variable assignments inside arrays

### DIFF
--- a/src/NodeResolvers/Expr/Array_.php
+++ b/src/NodeResolvers/Expr/Array_.php
@@ -3,6 +3,7 @@
 namespace Laravel\Surveyor\NodeResolvers\Expr;
 
 use Laravel\Surveyor\NodeResolvers\AbstractResolver;
+use Laravel\Surveyor\Result\VariableState;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\Type;
 use PhpParser\Node;
@@ -57,14 +58,14 @@ class Array_ extends AbstractResolver
 
                 if ($spreadValue instanceof ArrayType) {
                     foreach ($spreadValue->value as $value) {
-                        $result[] = $value;
+                        $result[] = $this->unwrapVariableState($value);
                     }
                 }
 
                 continue;
             }
 
-            $result[] = $this->from($item->value);
+            $result[] = $this->unwrapVariableState($this->from($item->value));
         }
 
         return Type::array($result);
@@ -84,16 +85,21 @@ class Array_ extends AbstractResolver
 
                 if ($spreadValue instanceof ArrayType) {
                     foreach ($spreadValue->value as $key => $value) {
-                        $result[$key] = $value;
+                        $result[$key] = $this->unwrapVariableState($value);
                     }
                 }
 
                 continue;
             }
 
-            $result[$item->key->value ?? null] = $this->from($item->value);
+            $result[$item->key->value ?? null] = $this->unwrapVariableState($this->from($item->value));
         }
 
         return Type::array($result);
+    }
+
+    protected function unwrapVariableState(mixed $value): mixed
+    {
+        return $value instanceof VariableState ? $value->type() : $value;
     }
 }

--- a/src/NodeResolvers/Expr/Array_.php
+++ b/src/NodeResolvers/Expr/Array_.php
@@ -3,7 +3,6 @@
 namespace Laravel\Surveyor\NodeResolvers\Expr;
 
 use Laravel\Surveyor\NodeResolvers\AbstractResolver;
-use Laravel\Surveyor\Result\VariableState;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\Type;
 use PhpParser\Node;
@@ -58,14 +57,14 @@ class Array_ extends AbstractResolver
 
                 if ($spreadValue instanceof ArrayType) {
                     foreach ($spreadValue->value as $value) {
-                        $result[] = $this->unwrapVariableState($value);
+                        $result[] = $value;
                     }
                 }
 
                 continue;
             }
 
-            $result[] = $this->unwrapVariableState($this->from($item->value));
+            $result[] = $this->from($item->value);
         }
 
         return Type::array($result);
@@ -85,21 +84,16 @@ class Array_ extends AbstractResolver
 
                 if ($spreadValue instanceof ArrayType) {
                     foreach ($spreadValue->value as $key => $value) {
-                        $result[$key] = $this->unwrapVariableState($value);
+                        $result[$key] = $value;
                     }
                 }
 
                 continue;
             }
 
-            $result[$item->key->value ?? null] = $this->unwrapVariableState($this->from($item->value));
+            $result[$item->key->value ?? null] = $this->from($item->value);
         }
 
         return Type::array($result);
-    }
-
-    protected function unwrapVariableState(mixed $value): mixed
-    {
-        return $value instanceof VariableState ? $value->type() : $value;
     }
 }

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -17,7 +17,10 @@ class Type
 
     public static function array($value): Contracts\Type
     {
-        return new ArrayType($value);
+        return new ArrayType(array_map(
+            fn ($v) => $v instanceof VariableState ? $v->type() : $v,
+            $value,
+        ));
     }
 
     public static function collapse(Contracts\Type $type): Contracts\Type

--- a/tests/Unit/ArrayResolverTest.php
+++ b/tests/Unit/ArrayResolverTest.php
@@ -459,3 +459,65 @@ class OnlySpreadTest
         unlink($fixture);
     });
 });
+
+describe('inline assignment expressions as array values', function () {
+    it('resolves keyed array inline assignments to their underlying type', function () {
+        $fixture = createPhpFixture('
+namespace App;
+
+class KeyedInlineAssignTest
+{
+    public function test(): array
+    {
+        return [
+            "stats" => $stats = ["a" => 1, "b" => 2],
+            "first" => $stats["a"],
+        ];
+    }
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        $method = $result->getMethod('test');
+        $returnType = $method->returnType();
+
+        expect($returnType)->toBeInstanceOf(ArrayType::class);
+        expect($returnType->value['stats'])->toBeInstanceOf(ArrayType::class);
+        expect($returnType->value['stats']->value['a'])->toBeInstanceOf(IntType::class);
+        expect($returnType->value['stats']->value['a']->value)->toBe(1);
+        expect($returnType->value['stats']->value['b']->value)->toBe(2);
+        expect($returnType->value['first'])->toBeInstanceOf(IntType::class);
+        expect($returnType->value['first']->value)->toBe(1);
+
+        unlink($fixture);
+    });
+
+    it('resolves list array inline assignments to their underlying type', function () {
+        $fixture = createPhpFixture('
+namespace App;
+
+class ListInlineAssignTest
+{
+    public function test(): array
+    {
+        return [$a = "hello", $a];
+    }
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        $method = $result->getMethod('test');
+        $returnType = $method->returnType();
+
+        expect($returnType)->toBeInstanceOf(ArrayType::class);
+        expect($returnType->isList())->toBeTrue();
+        expect($returnType->value[0])->toBeInstanceOf(StringType::class);
+        expect($returnType->value[0]->value)->toBe('hello');
+        expect($returnType->value[1])->toBeInstanceOf(StringType::class);
+        expect($returnType->value[1]->value)->toBe('hello');
+
+        unlink($fixture);
+    });
+});


### PR DESCRIPTION
This PR fixes Surveyor's handling of inline variable assignment inside arrays, like `['foo' => $bar = 42]`.

Currently these resolve to `VariableState`, but downstream code (including in Ranger and Wayfinder) expects resolved array values to be `Type` or scalar. 

The fix here explicitly unwraps array values with `$value->type()` if they're `VariableState`.

Added tests to confirm both that this fixes inline assignment and also doesn't break tracking the variables themselves when we find them this way.

Should fix laravel/wayfinder#160 and maybe similar subtle bugs in Ranger.