### PR TITLE
[0.x] Bump checkout action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2


### PR DESCRIPTION
I'm browsing a bunch of Laravel repos to appease the mind, but noticed these deprecations: 

<img width="1801" height="830" alt="image" src="https://github.com/user-attachments/assets/0409105e-a958-4f27-b38b-d18129cfb155" />



This PR fixes it on my little visit 🫡 