### PR TITLE
Expose class-level @property docblock tags as properties

### DIFF
--- a/src/Analyzed/PropertyResult.php
+++ b/src/Analyzed/PropertyResult.php
@@ -13,6 +13,8 @@ class PropertyResult
         public readonly bool $fromDocBlock = false,
         public readonly bool $modelAttribute = false,
         public readonly bool $modelRelation = false,
+        public readonly bool $readOnly = false,
+        public readonly bool $writeOnly = false,
     ) {
         //
     }

--- a/src/NodeResolvers/Stmt/Class_.php
+++ b/src/NodeResolvers/Stmt/Class_.php
@@ -92,9 +92,15 @@ class Class_ extends AbstractResolver
 
         $properties = $this->docBlockParser->parseProperties($node->getDocComment());
 
-        foreach ($properties as $name => $type) {
-            $this->scope->state()->addDocBlockProperty($name, $type);
-            $result->addProperty(new PropertyResult($name, $type, fromDocBlock: true));
+        foreach ($properties as $name => $details) {
+            $this->scope->state()->addDocBlockProperty($name, $details['type']);
+            $result->addProperty(new PropertyResult(
+                name: $name,
+                type: $details['type'],
+                fromDocBlock: true,
+                readOnly: $details['readOnly'],
+                writeOnly: $details['writeOnly'],
+            ));
         }
 
         $methods = $this->docBlockParser->parseMethods($node->getDocComment());

--- a/src/NodeResolvers/Stmt/Class_.php
+++ b/src/NodeResolvers/Stmt/Class_.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Resources\Json\ResourceCollection;
 use Laravel\Surveyor\Analysis\EntityType;
 use Laravel\Surveyor\Analyzed\ClassResult;
 use Laravel\Surveyor\Analyzed\MethodResult;
+use Laravel\Surveyor\Analyzed\PropertyResult;
 use Laravel\Surveyor\Analyzer\ModelAnalyzer;
 use Laravel\Surveyor\Analyzer\ResourceAnalyzer;
 use Laravel\Surveyor\NodeResolvers\AbstractResolver;
@@ -93,6 +94,10 @@ class Class_ extends AbstractResolver
 
         foreach ($properties as $name => $type) {
             $this->scope->state()->addDocBlockProperty($name, $type);
+
+            if (! $result->hasProperty($name)) {
+                $result->addProperty(new PropertyResult($name, $type, fromDocBlock: true));
+            }
         }
 
         $methods = $this->docBlockParser->parseMethods($node->getDocComment());

--- a/src/NodeResolvers/Stmt/Class_.php
+++ b/src/NodeResolvers/Stmt/Class_.php
@@ -94,10 +94,7 @@ class Class_ extends AbstractResolver
 
         foreach ($properties as $name => $type) {
             $this->scope->state()->addDocBlockProperty($name, $type);
-
-            if (! $result->hasProperty($name)) {
-                $result->addProperty(new PropertyResult($name, $type, fromDocBlock: true));
-            }
+            $result->addProperty(new PropertyResult($name, $type, fromDocBlock: true));
         }
 
         $methods = $this->docBlockParser->parseMethods($node->getDocComment());

--- a/src/Parser/DocBlockParser.php
+++ b/src/Parser/DocBlockParser.php
@@ -119,16 +119,27 @@ class DocBlockParser
     {
         $this->parse($docBlock);
 
-        $propertyTagValues = array_merge(
-            $this->parsed->getPropertyTagValues(),
-            $this->parsed->getPropertyReadTagValues(),
-            $this->parsed->getPropertyWriteTagValues()
-        );
+        $readWriteTags = $this->parsed->getPropertyTagValues();
+        $readTags = $this->parsed->getPropertyReadTagValues();
+        $writeTags = $this->parsed->getPropertyWriteTagValues();
+
+        $extractName = fn ($node) => ltrim($node->propertyName, '$');
+
+        $readWriteNames = array_map($extractName, $readWriteTags);
+        $readNames = array_map($extractName, $readTags);
+        $writeNames = array_map($extractName, $writeTags);
 
         $result = [];
 
-        foreach ($propertyTagValues as $node) {
-            $result[ltrim($node->propertyName, '$')] = $this->resolve($node);
+        foreach (array_merge($readWriteTags, $readTags, $writeTags) as $node) {
+            $name = $extractName($node);
+            $hasReadWrite = in_array($name, $readWriteNames, true);
+
+            $result[$name] = [
+                'type' => $this->resolve($node),
+                'readOnly' => ! $hasReadWrite && in_array($name, $readNames, true) && ! in_array($name, $writeNames, true),
+                'writeOnly' => ! $hasReadWrite && in_array($name, $writeNames, true) && ! in_array($name, $readNames, true),
+            ];
         }
 
         return $result;

--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -247,7 +247,7 @@ class Reflector
                 $result = $this->getDocBlockParser()->parseProperties($ref->getDocComment());
 
                 if (array_key_exists($name, $result)) {
-                    return $result[$name];
+                    return $result[$name]['type'];
                 }
             }
         }

--- a/tests/Unit/AnalyzerTest.php
+++ b/tests/Unit/AnalyzerTest.php
@@ -207,6 +207,60 @@ class DefaultValueClass
         unlink($fixture);
     });
 
+    it('exposes class-level @property docblock tags as properties', function () {
+        $fixture = createPhpFixture('
+namespace App;
+
+/**
+ * @property int $id
+ * @property string $email
+ * @property string|null $remember_token
+ * @property-read \Illuminate\Support\Carbon $created_at
+ */
+class DocBlockClass
+{
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        expect($result->hasProperty('id'))->toBeTrue();
+        expect($result->getProperty('id')->fromDocBlock)->toBeTrue();
+        expect($result->getProperty('id')->type)->toBeInstanceOf(IntType::class);
+
+        expect($result->hasProperty('email'))->toBeTrue();
+        expect($result->getProperty('email')->type)->toBeInstanceOf(StringType::class);
+
+        expect($result->hasProperty('remember_token'))->toBeTrue();
+        expect($result->getProperty('remember_token')->type->isNullable())->toBeTrue();
+
+        expect($result->hasProperty('created_at'))->toBeTrue();
+
+        unlink($fixture);
+    });
+
+    it('does not let class-level @property docblock tags overwrite real property declarations', function () {
+        $fixture = createPhpFixture('
+namespace App;
+
+/**
+ * @property string $name
+ */
+class MixedClass
+{
+    public int $name = 0;
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        $nameProp = $result->getProperty('name');
+        expect($nameProp->type)->toBeInstanceOf(IntType::class);
+        expect($nameProp->fromDocBlock)->toBeFalse();
+
+        unlink($fixture);
+    });
+
     it('uses explicit type declaration over default value inference', function () {
         $fixture = createPhpFixture('
 namespace App;

--- a/tests/Unit/AnalyzerTest.php
+++ b/tests/Unit/AnalyzerTest.php
@@ -261,6 +261,39 @@ class MixedClass
         unlink($fixture);
     });
 
+    it('flags @property-read as readOnly and @property-write as writeOnly', function () {
+        $fixture = createPhpFixture('
+namespace App;
+
+/**
+ * @property string $name
+ * @property-read int $id
+ * @property-write string $password
+ * @property string $email
+ * @property-read string $email
+ */
+class FlagsClass
+{
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        expect($result->getProperty('name')->readOnly)->toBeFalse();
+        expect($result->getProperty('name')->writeOnly)->toBeFalse();
+
+        expect($result->getProperty('id')->readOnly)->toBeTrue();
+        expect($result->getProperty('id')->writeOnly)->toBeFalse();
+
+        expect($result->getProperty('password')->readOnly)->toBeFalse();
+        expect($result->getProperty('password')->writeOnly)->toBeTrue();
+
+        expect($result->getProperty('email')->readOnly)->toBeFalse();
+        expect($result->getProperty('email')->writeOnly)->toBeFalse();
+
+        unlink($fixture);
+    });
+
     it('uses explicit type declaration over default value inference', function () {
         $fixture = createPhpFixture('
 namespace App;


### PR DESCRIPTION
Models, resources, and DTOs commonly declare their attributes via class-level @property/@property-read/@property-write PHPDoc rather than real public declarations. Until now those were stored on the scope (so $this->foo resolved correctly inside methods) but never surfaced on the ClassResult, so hasProperty() and publicProperties() reported nothing for a typical Eloquent model.

This adds them as PropertyResult entries with fromDocBlock: true. Real property declarations still take precedence since they are added after the class-level docblock is parsed and addProperty() overwrites by name.
