### PR TITLE
Resolve facades to their root class for method reflection

### DIFF
--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -446,6 +446,7 @@ class Reflector
     protected function resolveReflectedClass(string $className): ReflectionClass
     {
         $className = Util::resolveValidClass($className, $this->scope);
+        $className = Util::resolveClass($className);
 
         if (! Util::isClassOrInterface($className)) {
             throw new Exception('Class does not exist: '.$className);

--- a/tests/Unit/Resolvers/FacadeMethodTest.php
+++ b/tests/Unit/Resolvers/FacadeMethodTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Laravel\Surveyor\Analyzer\AnalyzedCache;
+use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Types\StringType;
+use Laravel\Surveyor\Types\Type;
+use Laravel\Surveyor\Types\UnionType;
+
+uses()->group('integration');
+
+beforeEach(function () {
+    AnalyzedCache::clear();
+});
+
+afterEach(function () {
+    AnalyzedCache::clear();
+});
+
+function findStringType(\Laravel\Surveyor\Types\Contracts\Type $type): ?StringType
+{
+    if ($type instanceof StringType) {
+        return $type;
+    }
+
+    if ($type instanceof UnionType) {
+        foreach ($type->types as $inner) {
+            if ($inner instanceof StringType) {
+                return $inner;
+            }
+        }
+    }
+
+    return null;
+}
+
+describe('Facade method resolution', function () {
+    it('resolves Config::string() to a string return type via the underlying Repository', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use Illuminate\\Support\\Facades\\Config;
+
+class ConfigController
+{
+    public function appName(): string
+    {
+        return Config::string(\'app.name\');
+    }
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        $returnType = $result->getMethod('appName')->returnType();
+
+        expect(Type::is($returnType, StringType::class) || $returnType instanceof UnionType)->toBeTrue();
+        expect(findStringType($returnType))->not->toBeNull();
+
+        unlink($fixture);
+    });
+});

--- a/tests/Unit/Resolvers/FacadeMethodTest.php
+++ b/tests/Unit/Resolvers/FacadeMethodTest.php
@@ -16,7 +16,7 @@ afterEach(function () {
     AnalyzedCache::clear();
 });
 
-function findStringType(\Laravel\Surveyor\Types\Contracts\Type $type): ?StringType
+function findStringType(Laravel\Surveyor\Types\Contracts\Type $type): ?StringType
 {
     if ($type instanceof StringType) {
         return $type;


### PR DESCRIPTION
Facade method calls like `Config::string('app.name')` were resolving to `mixed` because the `Reflector` was reflecting the facade itself, which only has `__callStatic`. The typed methods live on the underlying root class (`Illuminate\Config\Repository`), and the facade's `@method` PHPDoc tags aren't being parsed for vendor classes.

`Util::resolveClass()` already knows how to walk a facade to its root via `getFacadeRoot()`. We just weren't calling it. Adding that step in `resolveReflectedClass` lets reflection land on the class that actually declares the methods, so Wayfinder picks up real return types instead of emitting `unknown`.

Closes #22
