### PR TITLE
Treat corrupted disk cache files as a miss

### DIFF
--- a/src/Analyzer/AnalyzedCache.php
+++ b/src/Analyzer/AnalyzedCache.php
@@ -4,6 +4,7 @@ namespace Laravel\Surveyor\Analyzer;
 
 use Laravel\Surveyor\Analysis\Scope;
 use RuntimeException;
+use Throwable;
 
 use function Illuminate\Filesystem\join_paths;
 
@@ -129,9 +130,17 @@ class AnalyzedCache
             return null;
         }
 
-        $data = unserialize($serialized);
+        try {
+            $data = unserialize($serialized);
+        } catch (Throwable) {
+            static::invalidate($path);
+
+            return null;
+        }
 
         if (! is_array($data) || ! isset($data['mtime'], $data['scope'])) {
+            static::invalidate($path);
+
             return null;
         }
 

--- a/tests/Unit/Analyzer/AnalyzedCacheTest.php
+++ b/tests/Unit/Analyzer/AnalyzedCacheTest.php
@@ -276,6 +276,62 @@ describe('disk caching', function () {
         unlink($fixture);
         cleanupCacheDir($dir);
     });
+
+    it('treats a corrupted cache file as a miss and deletes it', function () {
+        $dir = createCacheDir();
+        AnalyzedCache::enableDiskCache($dir);
+
+        $fixture = createTestClassFixture('TestClass', 'public function test() {}');
+        $scope = new Scope;
+        $scope->setPath($fixture);
+        AnalyzedCache::add($fixture, $scope);
+
+        $cacheFiles = glob($dir.'/*.cache');
+        expect($cacheFiles)->toHaveCount(1);
+        $cacheFile = $cacheFiles[0];
+
+        $content = file_get_contents($cacheFile);
+        file_put_contents($cacheFile, substr($content, 0, intdiv(strlen($content), 2)).'garbage');
+
+        AnalyzedCache::clearMemory();
+
+        $cached = AnalyzedCache::get($fixture);
+        expect($cached)->toBeNull();
+        expect(file_exists($cacheFile))->toBeFalse();
+
+        unlink($fixture);
+        cleanupCacheDir($dir);
+    });
+
+    it('treats a signed cache file with corrupted payload as a miss and deletes it', function () {
+        $dir = createCacheDir();
+        AnalyzedCache::enableDiskCache($dir);
+        AnalyzedCache::setKey('base-secret-key');
+
+        $fixture = createTestClassFixture('TestClass', 'public function test() {}');
+        $scope = new Scope;
+        $scope->setPath($fixture);
+        AnalyzedCache::add($fixture, $scope);
+
+        $cacheFiles = glob($dir.'/*.cache');
+        expect($cacheFiles)->toHaveCount(1);
+        $cacheFile = $cacheFiles[0];
+
+        $content = file_get_contents($cacheFile);
+        [, $serialized] = explode(':', $content, 2);
+        $truncated = substr($serialized, 0, intdiv(strlen($serialized), 2));
+        $signature = hash_hmac('sha256', $truncated, 'base-secret-key');
+        file_put_contents($cacheFile, $signature.':'.$truncated);
+
+        AnalyzedCache::clearMemory();
+
+        $cached = AnalyzedCache::get($fixture);
+        expect($cached)->toBeNull();
+        expect(file_exists($cacheFile))->toBeFalse();
+
+        unlink($fixture);
+        cleanupCacheDir($dir);
+    });
 });
 
 describe('signed cache', function () {


### PR DESCRIPTION
If a cache file in `storage/wayfinder-cache/` ends up truncated or partially written (interrupted run, branch switch, etc.), `unserialize()` in `tryFromDisk()` throws an `ErrorException` ("Extra data starting at offset X of Y bytes") and kills the command until the user knows to delete the cache or pass `--fresh`.

Wraps `unserialize()` in a try/catch and routes any failure through `invalidate()`, which deletes the bad file and returns null so the analyzer regenerates it. The existing shape check (`is_array` / required keys) now also invalidates on mismatch instead of leaving the file behind.

Fixes laravel/wayfinder#171
