### PR TITLE
Preserve associative keys when resolving compact()

### DIFF
--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -135,7 +135,7 @@ class Reflector
             }
 
             return null;
-        })->filter()->values();
+        })->filter();
 
         return [Type::array($arr->all())];
     }

--- a/tests/Unit/ArrayResolverTest.php
+++ b/tests/Unit/ArrayResolverTest.php
@@ -521,3 +521,38 @@ class ListInlineAssignTest
         unlink($fixture);
     });
 });
+
+describe('compact() function', function () {
+    it('preserves variable names as keys', function () {
+        $fixture = createPhpFixture('
+namespace App;
+
+class CompactTest
+{
+    public function test(): array
+    {
+        $name = "Joe";
+        $age = 25;
+
+        return compact("name", "age");
+    }
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        $method = $result->getMethod('test');
+        $returnType = $method->returnType();
+
+        expect($returnType)->toBeInstanceOf(ArrayType::class);
+        expect($returnType->isList())->toBeFalse();
+        expect($returnType->value)->toHaveKey('name');
+        expect($returnType->value)->toHaveKey('age');
+        expect($returnType->value['name'])->toBeInstanceOf(StringType::class);
+        expect($returnType->value['name']->value)->toBe('Joe');
+        expect($returnType->value['age'])->toBeInstanceOf(IntType::class);
+        expect($returnType->value['age']->value)->toBe(25);
+
+        unlink($fixture);
+    });
+});


### PR DESCRIPTION
The compact() handler was calling ->values() on the resulting collection, which reset the variable-name keys to numeric indices. compact('name', 'age') ended up as a list-shaped array instead of one keyed by name and age, which breaks downstream consumers like Wayfinder's Inertia page prop type generation.

Closes laravel/wayfinder#141