### PR TITLE
Don't union AnonymousResourceCollection into Resource::collection() return type

### DIFF
--- a/src/NodeResolvers/Expr/StaticCall.php
+++ b/src/NodeResolvers/Expr/StaticCall.php
@@ -81,8 +81,14 @@ class StaticCall extends AbstractResolver
             return $attributeType;
         }
 
+        $entityReturnTypes = $this->handleEntities($class, $method, $node);
+
+        if ($class instanceof ClassType && $this->entitiesFullyDescribeReturnType($class, $method, $entityReturnTypes)) {
+            return Type::union(...$entityReturnTypes);
+        }
+
         $returnTypes = array_merge(
-            $this->handleEntities($class, $method, $node),
+            $entityReturnTypes,
             $this->reflector->methodReturnType($class, $method, $node),
         );
 
@@ -115,6 +121,23 @@ class StaticCall extends AbstractResolver
         }
 
         return [];
+    }
+
+    protected function entitiesFullyDescribeReturnType(ClassType $class, string $method, array $entityReturnTypes): bool
+    {
+        if (count($entityReturnTypes) === 0) {
+            return false;
+        }
+
+        // Resource ::collection() / ::make() entity types fully describe the return shape;
+        // unioning the documented AnonymousResourceCollection only adds noise.
+        if (! in_array($method, ['collection', 'make'], true)) {
+            return false;
+        }
+
+        $resolved = $class->resolved();
+
+        return class_exists($resolved) && is_subclass_of($resolved, JsonResource::class);
     }
 
     protected function handlePossibleResourceStaticCall(ClassType $class, bool $isCollection): array

--- a/tests/Unit/Resolvers/StaticCallTest.php
+++ b/tests/Unit/Resolvers/StaticCallTest.php
@@ -96,4 +96,32 @@ class CollectionController
 
         unlink($fixture);
     });
+
+    it('does not pollute Resource::collection() return type with the documented AnonymousResourceCollection class', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use App\\Http\\Resources\\UserResource;
+use App\\Models\\User;
+
+class CollectionController
+{
+    public function index()
+    {
+        return UserResource::collection(User::all());
+    }
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        $returnType = $result->getMethod('index')->returnType();
+
+        // The ResourceResponse fully describes this call — the documented
+        // Illuminate\Http\Resources\Json\AnonymousResourceCollection return
+        // shouldn't get unioned in alongside it.
+        expect($returnType)->toBeInstanceOf(ResourceResponse::class);
+
+        unlink($fixture);
+    });
 });


### PR DESCRIPTION
When a `JsonResource` subclass had `::collection()` or `::make()` called on it, the entity handler produced a `ResourceResponse` describing the resource shape, but the resolver also unioned in the documented return type from the doc-block (`Illuminate\Http\Resources\Json\AnonymousResourceCollection`). Downstream consumers ended up with both types in the union, which is noise: the `ResourceResponse` already fully describes the call.

This brings static resource calls in line with how `new Resource(...)` already works (entity wins, no doc-block union).

Fixes laravel/wayfinder#158
