### PR TITLE
Resolve `@template` bindings in `Arrayable` shapes and `Builder` method return types

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1055,16 +1055,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v13.7.0",
+            "version": "v13.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "f13b85b2cce7ef5e8f3bcdf2b6c6364bbdedae0b"
+                "reference": "a0c6ad03b380287015287d8d5a0fa2459e2332fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/f13b85b2cce7ef5e8f3bcdf2b6c6364bbdedae0b",
-                "reference": "f13b85b2cce7ef5e8f3bcdf2b6c6364bbdedae0b",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/a0c6ad03b380287015287d8d5a0fa2459e2332fd",
+                "reference": "a0c6ad03b380287015287d8d5a0fa2459e2332fd",
                 "shasum": ""
             },
             "require": {
@@ -1105,8 +1105,8 @@
                 "symfony/http-kernel": "^7.4.0 || ^8.0.0",
                 "symfony/mailer": "^7.4.0 || ^8.0.0",
                 "symfony/mime": "^7.4.0 || ^8.0.0",
-                "symfony/polyfill-php84": "^1.33",
-                "symfony/polyfill-php85": "^1.33",
+                "symfony/polyfill-php84": "^1.36",
+                "symfony/polyfill-php85": "^1.36",
                 "symfony/polyfill-php86": "^1.36",
                 "symfony/process": "^7.4.5 || ^8.0.5",
                 "symfony/routing": "^7.4.0 || ^8.0.0",
@@ -1168,7 +1168,7 @@
                 "aws/aws-sdk-php": "^3.322.9",
                 "ext-gmp": "*",
                 "fakerphp/faker": "^1.24",
-                "guzzlehttp/psr7": "^2.4",
+                "guzzlehttp/psr7": "^2.9",
                 "laravel/pint": "^1.18",
                 "league/flysystem-aws-s3-v3": "^3.25.1",
                 "league/flysystem-ftp": "^3.25.1",
@@ -1275,7 +1275,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-04-28T17:18:25+00:00"
+            "time": "2026-05-13T15:38:40+00:00"
         },
         {
             "name": "laravel/prompts",

--- a/src/Analyzed/ClassLikeResult.php
+++ b/src/Analyzed/ClassLikeResult.php
@@ -5,6 +5,7 @@ namespace Laravel\Surveyor\Analyzed;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 use Laravel\Surveyor\Analysis\EntityType;
+use Laravel\Surveyor\Types\TemplateTagType;
 use Laravel\Surveyor\Types\Type;
 
 class ClassLikeResult
@@ -20,6 +21,9 @@ class ClassLikeResult
 
     /** @var array<string, MethodResult> */
     protected array $methods = [];
+
+    /** @var array<string, TemplateTagType> */
+    protected array $templateTags = [];
 
     protected bool $arrayable = false;
 
@@ -204,5 +208,26 @@ class ClassLikeResult
     public function getUse(string $name): ?string
     {
         return $this->uses[$name] ?? null;
+    }
+
+    public function addTemplateTag(TemplateTagType $tag): void
+    {
+        $this->templateTags[$tag->name] = $tag;
+    }
+
+    /** @return array<string, TemplateTagType> */
+    public function templateTags(): array
+    {
+        return $this->templateTags;
+    }
+
+    public function hasTemplateTag(string $name): bool
+    {
+        return isset($this->templateTags[$name]);
+    }
+
+    public function getTemplateTag(string $name): ?TemplateTagType
+    {
+        return $this->templateTags[$name] ?? null;
     }
 }

--- a/src/Analyzer/ArrayableResolver.php
+++ b/src/Analyzer/ArrayableResolver.php
@@ -5,14 +5,18 @@ namespace Laravel\Surveyor\Analyzer;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 use Laravel\Surveyor\Analyzed\ClassLikeResult;
+use Laravel\Surveyor\Concerns\SubstitutesTemplateBindings;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
+use Laravel\Surveyor\Types\StringType;
 use ReflectionClass;
 use Throwable;
 
 class ArrayableResolver
 {
+    use SubstitutesTemplateBindings;
+
     public function __construct(
         protected Analyzer $analyzer,
     ) {
@@ -67,7 +71,7 @@ class ArrayableResolver
             $returnType = $analyzed->getMethod('toArray')->returnType();
 
             if ($returnType instanceof ArrayType) {
-                return $returnType;
+                return $this->substituteTemplateBindings($type, $analyzed, $returnType);
             }
         }
 
@@ -75,10 +79,33 @@ class ArrayableResolver
             $returnType = $analyzed->getMethod('jsonSerialize')->returnType();
 
             if ($returnType instanceof ArrayType) {
-                return $returnType;
+                return $this->substituteTemplateBindings($type, $analyzed, $returnType);
             }
         }
 
         return null;
+    }
+
+    protected function substituteTemplateBindings(ClassType $callerType, ClassLikeResult $analyzed, ArrayType $resolved): ArrayType
+    {
+        $templateTags = array_values($analyzed->templateTags());
+        $genericTypes = array_values($callerType->genericTypes());
+
+        if (empty($templateTags) || empty($genericTypes)) {
+            return $resolved;
+        }
+
+        $bindings = [];
+        foreach ($templateTags as $i => $tag) {
+            if (isset($genericTypes[$i]) && ! $genericTypes[$i] instanceof StringType) {
+                $bindings[$tag->name] = $genericTypes[$i];
+            }
+        }
+
+        if (empty($bindings)) {
+            return $resolved;
+        }
+
+        return $this->substituteInArrayType($resolved, $bindings);
     }
 }

--- a/src/Concerns/SubstitutesTemplateBindings.php
+++ b/src/Concerns/SubstitutesTemplateBindings.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Laravel\Surveyor\Concerns;
+
+use Laravel\Surveyor\Types\ArrayShapeType;
+use Laravel\Surveyor\Types\ArrayType;
+use Laravel\Surveyor\Types\ClassType;
+use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
+use Laravel\Surveyor\Types\StringType;
+use Laravel\Surveyor\Types\Type;
+use Laravel\Surveyor\Types\UnionType;
+
+trait SubstitutesTemplateBindings
+{
+    protected function substituteInType(TypeContract $type, array $bindings): TypeContract
+    {
+        return match (true) {
+            $type instanceof StringType && isset($bindings[$type->value]) => $bindings[$type->value],
+            $type instanceof ArrayShapeType => new ArrayShapeType(
+                $this->substituteInType($type->keyType, $bindings),
+                $this->substituteInType($type->valueType, $bindings),
+            ),
+            $type instanceof ArrayType => $this->substituteInArrayType($type, $bindings),
+            $type instanceof UnionType => Type::union(...array_map(fn ($t) => $this->substituteInType($t, $bindings), $type->types)),
+            $type instanceof ClassType && ! empty($type->genericTypes()) => (clone $type)->setGenericTypes(
+                array_map(fn ($g) => $this->substituteInType($g, $bindings), $type->genericTypes())
+            ),
+            default => $type,
+        };
+    }
+
+    protected function substituteInArrayType(ArrayType $type, array $bindings): ArrayType
+    {
+        $newValues = [];
+        foreach ($type->value as $key => $value) {
+            $newValues[$key] = $this->substituteInType($value, $bindings);
+        }
+
+        return new ArrayType($newValues);
+    }
+}

--- a/src/NodeResolvers/Shared/ParsesClassLikeDocBlock.php
+++ b/src/NodeResolvers/Shared/ParsesClassLikeDocBlock.php
@@ -51,5 +51,9 @@ trait ParsesClassLikeDocBlock
 
             $result->addMethod($methodResult);
         }
+
+        foreach ($this->docBlockParser->resolveTemplateTags($node->getDocComment()) as $tag) {
+            $result->addTemplateTag($tag);
+        }
     }
 }

--- a/src/NodeResolvers/Shared/ResolvesMethodCalls.php
+++ b/src/NodeResolvers/Shared/ResolvesMethodCalls.php
@@ -27,19 +27,18 @@ trait ResolvesMethodCalls
         $methodName = $this->from($node->name);
 
         if (! Type::is($methodName, StringType::class) || $methodName->value === null) {
-            // Method names that happen to match PHP function names resolve as ClassType
-            // due to Util::isClassOrInterface(). Handle resource conditionals here before
-            // returning mixed, since methods like when() collide with Laravel's when() helper.
-            if (
-                $methodName instanceof ClassType
-                && $methodName->value !== null
-                && in_array($methodName->value, static::$conditionalMethods)
-                && $this->isJsonResource($var)
-            ) {
-                return $this->resolveResourceConditional($var, $methodName->value, $node);
-            }
+            // Method names that happen to match PHP function/class names resolve as ClassType
+            // due to Util::isClassOrInterface(). If the value has no namespace separator it's
+            // a simple identifier mis-identified as a class; treat it as the method name.
+            if ($methodName instanceof ClassType && $methodName->value !== null && ! str_contains($methodName->value, '\\')) {
+                if (in_array($methodName->value, static::$conditionalMethods) && $this->isJsonResource($var)) {
+                    return $this->resolveResourceConditional($var, $methodName->value, $node);
+                }
 
-            return Type::mixed();
+                $methodName = Type::string($methodName->value);
+            } else {
+                return Type::mixed();
+            }
         }
 
         switch ($var->value) {

--- a/src/NodeResolvers/Shared/ResolvesMethodCalls.php
+++ b/src/NodeResolvers/Shared/ResolvesMethodCalls.php
@@ -3,6 +3,7 @@
 namespace Laravel\Surveyor\NodeResolvers\Shared;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Request as RequestFacade;
 use Laravel\Surveyor\Concerns\LazilyLoadsDependencies;
 use Laravel\Surveyor\Types\ClassType;
@@ -56,6 +57,16 @@ trait ResolvesMethodCalls
 
         if (in_array($methodName->value, static::$conditionalMethods) && $this->isJsonResource($var)) {
             return $this->resolveResourceConditional($var, $methodName->value, $node);
+        }
+
+        if (
+            $methodName->value === 'toArray'
+            && count($var->genericTypes()) >= 2
+            && is_a($this->scope->getUse($var->value), Collection::class, true)
+        ) {
+            $genericTypes = array_values($var->genericTypes());
+
+            return Type::arrayShape($genericTypes[0], $genericTypes[1]);
         }
 
         return Type::union(

--- a/src/NodeResolvers/Stmt/Class_.php
+++ b/src/NodeResolvers/Stmt/Class_.php
@@ -50,6 +50,10 @@ class Class_ extends AbstractResolver
 
         $this->parseClassLikeDocBlock($node, $result);
 
+        if (! empty($result->templateTags())) {
+            $this->scope->setTemplateTags(array_values($result->templateTags()));
+        }
+
         if ($this->extendsResource()) {
             try {
                 app(ResourceAnalyzer::class)->injectModelProperties($result->name(), $result, $this->scope);

--- a/src/Parser/DocBlockParser.php
+++ b/src/Parser/DocBlockParser.php
@@ -5,6 +5,7 @@ namespace Laravel\Surveyor\Parser;
 use Illuminate\Support\Arr;
 use Laravel\Surveyor\Analysis\Scope;
 use Laravel\Surveyor\Resolvers\DocBlockResolver;
+use Laravel\Surveyor\Types\TemplateTagType;
 use Laravel\Surveyor\Types\Type;
 // use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 // use Laravel\Surveyor\Types\Type as RangerType;
@@ -108,11 +109,41 @@ class DocBlockParser
     {
         $this->parse($docBlock);
 
-        $templateTags = array_map(fn ($tag) => $this->resolve($tag), $this->parsed->getTemplateTagValues());
+        $allTags = array_merge(
+            $this->parsed->getTemplateTagValues('@template'),
+            $this->parsed->getTemplateTagValues('@template-covariant'),
+            $this->parsed->getTemplateTagValues('@template-contravariant'),
+        );
+
+        $templateTags = array_map(fn ($tag) => $this->resolve($tag), $allTags);
 
         $this->scope->setTemplateTags($templateTags);
 
-        return $this->parsed->getTemplateTagValues();
+        return $allTags;
+    }
+
+    /**
+     * @return array<string, TemplateTagType>
+     */
+    public function resolveTemplateTags(string $docBlock): array
+    {
+        $this->parse($docBlock);
+
+        $allTags = array_merge(
+            $this->parsed->getTemplateTagValues('@template'),
+            $this->parsed->getTemplateTagValues('@template-covariant'),
+            $this->parsed->getTemplateTagValues('@template-contravariant'),
+        );
+
+        $result = [];
+        foreach ($allTags as $tag) {
+            $resolved = $this->resolve($tag);
+            if ($resolved instanceof TemplateTagType) {
+                $result[$resolved->name] = $resolved;
+            }
+        }
+
+        return $result;
     }
 
     public function parseProperties(string $docBlock): array

--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -10,7 +10,9 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
 use Laravel\Surveyor\Analysis\Scope;
+use Laravel\Surveyor\Analyzed\ClassLikeResult;
 use Laravel\Surveyor\Concerns\LazilyLoadsDependencies;
+use Laravel\Surveyor\Concerns\SubstitutesTemplateBindings;
 use Laravel\Surveyor\Debug\Debug;
 use Laravel\Surveyor\Support\Util;
 use Laravel\Surveyor\Types\ArrayType;
@@ -30,7 +32,7 @@ use Throwable;
 
 class Reflector
 {
-    use LazilyLoadsDependencies;
+    use LazilyLoadsDependencies, SubstitutesTemplateBindings;
 
     protected Scope $scope;
 
@@ -346,10 +348,20 @@ class Reflector
         }
 
         if (count($returnTypes) === 0 && $reflection->isSubclassOf(Model::class)) {
-            array_push(
-                $returnTypes,
-                ...$this->methodReturnType(Builder::class, $method, $node),
-            );
+            $builderTypes = $this->methodReturnType(Builder::class, $method, $node);
+
+            $builderResult = $this->getAnalyzer()
+                ->analyzeClass(Builder::class)
+                ->result();
+
+            if ($builderResult instanceof ClassLikeResult && ! empty($builderResult->templateTags())) {
+                $builderTypes = array_map(
+                    fn ($type) => $this->bindCallerTemplates($type, $className, $builderResult),
+                    $builderTypes,
+                );
+            }
+
+            array_push($returnTypes, ...$builderTypes);
         }
 
         if (count($returnTypes) > 0) {
@@ -469,5 +481,21 @@ class Reflector
         $this->appBindings ??= app()->getBindings();
 
         return $this->appBindings[$key] ?? null;
+    }
+
+    protected function bindCallerTemplates(TypeContract $type, string $callerClass, ClassLikeResult $calleeResult): TypeContract
+    {
+        $bindings = [];
+        foreach ($calleeResult->templateTags() as $tag) {
+            if ($tag->bound instanceof ClassType && is_a($callerClass, $tag->bound->value, true)) {
+                $bindings[$tag->name] = new ClassType($callerClass);
+            }
+        }
+
+        if (empty($bindings)) {
+            return $type;
+        }
+
+        return $this->substituteInType($type, $bindings);
     }
 }

--- a/tests/Unit/Analyzed/ClassLikeResultTest.php
+++ b/tests/Unit/Analyzed/ClassLikeResultTest.php
@@ -6,6 +6,7 @@ use Laravel\Surveyor\Analysis\EntityType;
 use Laravel\Surveyor\Analyzed\ClassLikeResult;
 use Laravel\Surveyor\Analyzed\MethodResult;
 use Laravel\Surveyor\Analyzed\PropertyResult;
+use Laravel\Surveyor\Types\TemplateTagType;
 use Laravel\Surveyor\Types\Type;
 
 uses()->group('results');
@@ -170,6 +171,52 @@ describe('uses', function () {
 
         expect($result->getUse('Request'))->toBe('Illuminate\\Http\\Request');
         expect($result->getUse('NonExistent'))->toBeNull();
+    });
+});
+
+describe('template tags', function () {
+    it('starts with no template tags', function () {
+        $result = createClassLikeResult();
+        expect($result->templateTags())->toBe([]);
+        expect($result->hasTemplateTag('T'))->toBeFalse();
+        expect($result->getTemplateTag('T'))->toBeNull();
+    });
+
+    it('stores and retrieves a template tag by name', function () {
+        $result = createClassLikeResult();
+        $tag = new TemplateTagType(name: 'TValue', bound: null, default: null, lowerBound: null, description: null);
+
+        $result->addTemplateTag($tag);
+
+        expect($result->hasTemplateTag('TValue'))->toBeTrue();
+        expect($result->getTemplateTag('TValue'))->toBe($tag);
+    });
+
+    it('returns all template tags keyed by name', function () {
+        $result = createClassLikeResult();
+        $tKey = new TemplateTagType(name: 'TKey', bound: Type::string(), default: null, lowerBound: null, description: null);
+        $tValue = new TemplateTagType(name: 'TValue', bound: null, default: null, lowerBound: null, description: null);
+
+        $result->addTemplateTag($tKey);
+        $result->addTemplateTag($tValue);
+
+        $tags = $result->templateTags();
+        expect($tags)->toHaveCount(2);
+        expect(array_keys($tags))->toBe(['TKey', 'TValue']);
+        expect($tags['TKey'])->toBe($tKey);
+        expect($tags['TValue'])->toBe($tValue);
+    });
+
+    it('overwrites an existing tag when added with the same name', function () {
+        $result = createClassLikeResult();
+        $first = new TemplateTagType(name: 'T', bound: null, default: null, lowerBound: null, description: null);
+        $second = new TemplateTagType(name: 'T', bound: Type::int(), default: null, lowerBound: null, description: null);
+
+        $result->addTemplateTag($first);
+        $result->addTemplateTag($second);
+
+        expect($result->templateTags())->toHaveCount(1);
+        expect($result->getTemplateTag('T'))->toBe($second);
     });
 });
 

--- a/tests/Unit/Analyzer/ArrayableResolverTest.php
+++ b/tests/Unit/Analyzer/ArrayableResolverTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Laravel\Surveyor\Analyzer\AnalyzedCache;
+use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Analyzer\ArrayableResolver;
+use Laravel\Surveyor\Types\ArrayShapeType;
+use Laravel\Surveyor\Types\ArrayType;
+use Laravel\Surveyor\Types\ClassType;
+use Laravel\Surveyor\Types\IntType;
+use Laravel\Surveyor\Types\StringType;
+
+uses()->group('integration');
+
+beforeAll(function () {
+    AnalyzedCache::clear();
+});
+
+afterAll(function () {
+    AnalyzedCache::clear();
+});
+
+describe('ArrayableResolver substituteTemplateBindings', function () {
+    it('substitutes @template placeholders in toArray() using caller ClassType generics', function () {
+        $type = (new ClassType(LengthAwarePaginator::class))
+            ->setGenericTypes([new IntType, new ClassType(User::class)]);
+
+        $result = app(ArrayableResolver::class)->resolve($type);
+
+        expect($result)->toBeInstanceOf(ArrayType::class);
+
+        $data = $result->value['data'] ?? null;
+        expect($data)->not->toBeNull();
+        expect($data)->toBeInstanceOf(ArrayShapeType::class);
+
+        // TValue (index 1, ClassType(User)): not the raw placeholder StringType('TValue')
+        expect($data->valueType)->toBeInstanceOf(ClassType::class);
+        expect($data->valueType->value)->toBe(User::class);
+
+        // TKey (index 0, IntType): not the raw placeholder StringType('TKey')
+        expect($data->keyType)->toBeInstanceOf(IntType::class);
+    });
+
+    it('returns the resolved ArrayType unchanged when the caller provides no generics', function () {
+        $type = new ClassType(LengthAwarePaginator::class);
+
+        $result = app(ArrayableResolver::class)->resolve($type);
+
+        expect($result)->toBeInstanceOf(ArrayType::class);
+
+        $data = $result->value['data'] ?? null;
+        expect($data)->not->toBeNull();
+        expect($data)->toBeInstanceOf(ArrayShapeType::class);
+        expect($data->valueType)->toBeInstanceOf(StringType::class);
+    });
+});
+
+describe('Reflector caller-side template binding', function () {
+    it('binds TModel to the concrete Model subclass when resolving Builder methods via Reflector', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use App\\Models\\User;
+
+class UserPaginatorController
+{
+    public function index()
+    {
+        return User::paginate(15);
+    }
+}
+');
+
+        $result = app(Analyzer::class)->analyze($fixture)->result();
+        $returnType = $result->getMethod('index')->returnType();
+
+        expect($returnType)->toBeInstanceOf(ClassType::class);
+        expect($returnType->value)->toBe(LengthAwarePaginator::class);
+
+        $generics = $returnType->genericTypes();
+        expect($generics)->toHaveCount(2);
+
+        expect($generics[0])->toBeInstanceOf(IntType::class);
+
+        expect($generics[1])->toBeInstanceOf(ClassType::class);
+        expect($generics[1]->value)->toBe(User::class);
+
+        unlink($fixture);
+    });
+
+    it('produces a fully resolved data shape', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use App\\Models\\User;
+
+class UserPaginatorController
+{
+    public function index()
+    {
+        return User::paginate(15);
+    }
+}
+');
+
+        $result = app(Analyzer::class)->analyze($fixture)->result();
+        $returnType = $result->getMethod('index')->returnType();
+        $resolved = app(ArrayableResolver::class)->resolve($returnType);
+
+        expect($resolved)->toBeInstanceOf(ArrayType::class);
+
+        $data = $resolved->value['data'] ?? null;
+        expect($data)->not->toBeNull();
+        expect($data)->toBeInstanceOf(ArrayShapeType::class);
+        expect($data->valueType)->toBeInstanceOf(ClassType::class);
+        expect($data->valueType->value)->toBe(User::class);
+
+        unlink($fixture);
+    });
+});

--- a/tests/Unit/AnalyzerTest.php
+++ b/tests/Unit/AnalyzerTest.php
@@ -10,6 +10,7 @@ use Laravel\Surveyor\Types\BoolType;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\IntType;
 use Laravel\Surveyor\Types\StringType;
+use Laravel\Surveyor\Types\TemplateTagType;
 use Laravel\Surveyor\Types\Type;
 use Laravel\Surveyor\Types\UnionType;
 use Laravel\Surveyor\Types\VoidType;
@@ -620,6 +621,96 @@ class TestController
         $scope = $analyzer->analyze($fixture)->analyzed();
 
         expect($scope->namespace())->toBe('App\\Http\\Controllers');
+
+        unlink($fixture);
+    });
+});
+
+describe('template tag storage in ClassLikeResult', function () {
+    it('stores @template declarations from a class docblock', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
+class TemplatedCollection {}
+');
+
+        $result = app(Analyzer::class)->analyze($fixture)->result();
+
+        expect($result)->toBeInstanceOf(ClassLikeResult::class);
+        expect($result->hasTemplateTag('TKey'))->toBeTrue();
+        expect($result->hasTemplateTag('TValue'))->toBeTrue();
+
+        $tKey = $result->getTemplateTag('TKey');
+        expect($tKey)->toBeInstanceOf(TemplateTagType::class);
+        expect($tKey->name)->toBe('TKey');
+        expect($tKey->bound)->not->toBeNull();
+
+        $tValue = $result->getTemplateTag('TValue');
+        expect($tValue)->toBeInstanceOf(TemplateTagType::class);
+        expect($tValue->name)->toBe('TValue');
+        expect($tValue->bound)->toBeNull();
+
+        unlink($fixture);
+    });
+
+    it('returns empty templateTags() for a class with no @template annotations', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+class PlainClass {}
+');
+
+        $result = app(Analyzer::class)->analyze($fixture)->result();
+
+        expect($result->templateTags())->toBe([]);
+
+        unlink($fixture);
+    });
+
+    it('stores @template declarations from an interface docblock', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+/**
+ * @template TItem
+ */
+interface CollectionInterface {}
+');
+
+        $result = app(Analyzer::class)->analyze($fixture)->result();
+
+        expect($result)->toBeInstanceOf(ClassLikeResult::class);
+        expect($result->hasTemplateTag('TItem'))->toBeTrue();
+        expect($result->getTemplateTag('TItem')->name)->toBe('TItem');
+
+        unlink($fixture);
+    });
+
+    it('substitutes class template names with their bounds in property @var annotations', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
+class TemplatedCollection
+{
+    /** @var array<TKey, TValue> */
+    public $data;
+}
+');
+
+        $result = app(Analyzer::class)->analyze($fixture)->result();
+        $propType = $result->getProperty('data')->type;
+
+        expect($propType)->toBeInstanceOf(ArrayShapeType::class);
+        expect($propType->keyType)->toBeInstanceOf(StringType::class);
+        expect($propType->keyType->value)->toBe('array-key');
 
         unlink($fixture);
     });


### PR DESCRIPTION
## summary

this change parses and stores `@template`, `@template-covariant`, and `@template-contravariant` docblock tags on `ClassLikeResult`, giving every analyzed class a typed record of its generic parameters.

## e2e flow

given a controller returning `Product::paginate(5)` inside an `Inertia::render()` call:

1. `Product::paginate(5)` falls back to `Builder::paginate()` since `Product` doesn't define it
2. `Builder`'s `ClassLikeResult::templateTags()` contains `TModel of Model`
3. `bindCallerTemplates` -> `["TModel" => ClassType(Product)]`
4. `substituteInType` replaces `StringType("TModel")` -> `ClassType(Product)`
5. result: `ClassType(LengthAwarePaginator, genericTypes: [IntType, ClassType(Product)])`
6. `ArrayableResolver` resolves `LengthAwarePaginator::toArray()`; `data` key contains `StringType('TKey')`|`StringType('TValue')` placeholders because the `Collection::toArray()` fast path surfaces them directly from the collection's generic types
7. `substituteTemplateBindings` maps `TKey -> IntType`, `TValue -> ClassType(Product)`
8. `data: App.Models.Product[]` emitted in generated TypeScript

## related

- https://github.com/laravel/framework/pull/60045
- https://github.com/laravel/wayfinder/pull/249

## merge order

https://github.com/laravel/framework/pull/60045 -> `this` -> https://github.com/laravel/wayfinder/pull/249