### PR TITLE
Allow @var docblocks on array items to override inferred type

### DIFF
--- a/src/NodeResolvers/Expr/Array_.php
+++ b/src/NodeResolvers/Expr/Array_.php
@@ -3,7 +3,9 @@
 namespace Laravel\Surveyor\NodeResolvers\Expr;
 
 use Laravel\Surveyor\NodeResolvers\AbstractResolver;
+use Laravel\Surveyor\Result\VariableState;
 use Laravel\Surveyor\Types\ArrayType;
+use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 use Laravel\Surveyor\Types\Type;
 use PhpParser\Node;
 
@@ -64,7 +66,7 @@ class Array_ extends AbstractResolver
                 continue;
             }
 
-            $result[] = $this->from($item->value);
+            $result[] = $this->resolveItemValue($item);
         }
 
         return Type::array($result);
@@ -91,9 +93,26 @@ class Array_ extends AbstractResolver
                 continue;
             }
 
-            $result[$item->key->value ?? null] = $this->from($item->value);
+            $result[$item->key->value ?? null] = $this->resolveItemValue($item);
         }
 
         return Type::array($result);
+    }
+
+    protected function resolveItemValue(Node\ArrayItem $item): TypeContract
+    {
+        if ($comment = $item->getDocComment()) {
+            if ($type = $this->docBlockParser->parseVar($comment->getText())) {
+                return $type;
+            }
+        }
+
+        $type = $this->from($item->value);
+
+        return match (true) {
+            $type instanceof VariableState => $type->type(),
+            $type instanceof TypeContract => $type,
+            default => Type::mixed(),
+        };
     }
 }

--- a/src/NodeResolvers/Expr/Array_.php
+++ b/src/NodeResolvers/Expr/Array_.php
@@ -110,6 +110,7 @@ class Array_ extends AbstractResolver
         $type = $this->from($item->value);
 
         return match (true) {
+            $type instanceof VariableState => $type->type(),
             $type instanceof TypeContract => $type,
             default => Type::mixed(),
         };

--- a/src/NodeResolvers/Expr/Array_.php
+++ b/src/NodeResolvers/Expr/Array_.php
@@ -110,7 +110,6 @@ class Array_ extends AbstractResolver
         $type = $this->from($item->value);
 
         return match (true) {
-            $type instanceof VariableState => $type->type(),
             $type instanceof TypeContract => $type,
             default => Type::mixed(),
         };

--- a/tests/Unit/ArrayResolverTest.php
+++ b/tests/Unit/ArrayResolverTest.php
@@ -2,6 +2,7 @@
 
 use Laravel\Surveyor\Analyzer\AnalyzedCache;
 use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Types\ArrayShapeType;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\BoolType;
 use Laravel\Surveyor\Types\FloatType;
@@ -76,6 +77,43 @@ class KeyedArrayTest
         expect($returnType->value['name']->value)->toBe('Joe');
         expect($returnType->value['age'])->toBeInstanceOf(IntType::class);
         expect($returnType->value['age']->value)->toBe(25);
+
+        unlink($fixture);
+    });
+
+    it('uses array item var docblocks to override inferred values', function () {
+        $fixture = createPhpFixture('
+namespace App;
+
+class KeyedArrayDocBlockTest
+{
+    public function test(): array
+    {
+        return [
+            /** @var list<array{value:int,label:string}> */
+            "categories" => $this->options(),
+        ];
+    }
+
+    public function options(): mixed
+    {
+        return [];
+    }
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        $method = $result->getMethod('test');
+        $returnType = $method->returnType();
+        $categories = $returnType->value['categories'];
+
+        expect($returnType)->toBeInstanceOf(ArrayType::class);
+        expect($categories)->toBeInstanceOf(ArrayShapeType::class);
+        expect($categories->keyType)->toBeInstanceOf(IntType::class);
+        expect($categories->valueType)->toBeInstanceOf(ArrayType::class);
+        expect($categories->valueType->value['value'])->toBeInstanceOf(IntType::class);
+        expect($categories->valueType->value['label'])->toBeInstanceOf(StringType::class);
 
         unlink($fixture);
     });


### PR DESCRIPTION
## Summary

Adds support for a `@var` PHPDoc comment placed immediately before an array item to override the inferred type of that item.

```php
return Inertia::render('Authors/createOrEdit', [
    'author' => $author,
    /** @var list<array{value:int,label:string}> */
    'categories' => Category::query()->orderBy('name')->get()
        ->map(fn (Category $c) => ['value' => $c->id, 'label' => $c->name])
        ->values()->all(),
]);
```

## Motivation

Static analysis cannot follow Collection pipelines deeply enough to infer the shape produced by `->map(fn () => [...])->values()->all()`, or recover SQL aliases from `select('id as value', 'name as label')`. Those props currently resolve to `mixed` / `unknown` in downstream consumers (Ranger → Wayfinder TypeScript).

Until full closure-return → generic-template binding is implemented for Collection chains, this gives users a precise, local escape hatch using the docblock shapes Surveyor already understands.

## Changes

- `src/NodeResolvers/Expr/Array_.php` — extract item resolution into `resolveItemValue()`, which checks for a doc comment on the `ArrayItem` node and runs it through the existing `DocBlockParser::parseVar()` before falling back to inference. Used by both list and keyed array paths.
- `tests/Unit/ArrayResolverTest.php` — new test covering a keyed array item annotated with `/** @var list<array{value:int,label:string}> */`, asserting it resolves to `ArrayShapeType<int, ArrayType{value:int,label:string}>`.

## Test plan

- [x] `./vendor/bin/pest tests/Unit/ArrayResolverTest.php`
- [x] `./vendor/bin/pint src/NodeResolvers/Expr/Array_.php tests/Unit/ArrayResolverTest.php`
- [x] Existing list/keyed-array tests still pass (resolver is a no-op when no doc comment is present).