### PR TITLE
Fix method resolution for names that are PHP type keywords

### DIFF
--- a/src/NodeResolvers/Shared/ResolvesMethodCalls.php
+++ b/src/NodeResolvers/Shared/ResolvesMethodCalls.php
@@ -23,7 +23,9 @@ trait ResolvesMethodCalls
             return Type::mixed();
         }
 
-        $methodName = $this->from($node->name);
+        $methodName = $node->name instanceof Node\Identifier
+            ? new StringType($node->name->name)
+            : $this->from($node->name);
 
         if (! Type::is($methodName, StringType::class) || $methodName->value === null) {
             // Method names that happen to match PHP function names resolve as ClassType

--- a/tests/Unit/ConfigResolverTest.php
+++ b/tests/Unit/ConfigResolverTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Laravel\Surveyor\Analyzer\AnalyzedCache;
+use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Types\MixedType;
+use Laravel\Surveyor\Types\StringType;
+
+beforeEach(fn () => AnalyzedCache::clear());
+afterEach(fn () => AnalyzedCache::clear());
+
+it('resolves config()->string() to string', function () {
+    $fixture = createPhpFixture('
+namespace App;
+
+class Test
+{
+    public function test()
+    {
+        return config()->string("app.name");
+    }
+}');
+
+    $result = app(Analyzer::class)->analyze($fixture)->result();
+    $returnType = $result->getMethod('test')->returnType();
+
+    expect($returnType)->toBeInstanceOf(StringType::class);
+
+    unlink($fixture);
+});
+
+it('resolves config() with a string key to mixed', function () {
+    $fixture = createPhpFixture('
+namespace App;
+
+class Test
+{
+    public function test()
+    {
+        return config("app.name");
+    }
+}');
+
+    $result = app(Analyzer::class)->analyze($fixture)->result();
+    $returnType = $result->getMethod('test')->returnType();
+
+    expect($returnType)->toBeInstanceOf(MixedType::class);
+
+    unlink($fixture);
+});


### PR DESCRIPTION
When a method is named after a PHP primitive type keyword (string, int, bool, array, etc.), resolveMethodCall was routing the identifier through Type::from(), which normalizes those keywords into typeless type objects with a null value. The null value check then caused an early return of mixed before ever looking up the method.

The fix mirrors what StaticCall already does: when the method name is a literal Node\Identifier, use the name directly as a StringType value instead of going through the type resolver. This fixes config()->string() and any other method call where the method name is a reserved type word.
