### PR TITLE
Fix Eloquent builder method resolution via @mixin and integer range types

### DIFF
--- a/src/DocBlockResolvers/Type/GenericTypeNode.php
+++ b/src/DocBlockResolvers/Type/GenericTypeNode.php
@@ -42,6 +42,12 @@ class GenericTypeNode extends AbstractResolver
                 return Type::union(...$genericTypes);
             case 'iterable':
                 return $this->handleIterableType($node, $genericTypes);
+            case 'int':
+            case 'positive-int':
+            case 'negative-int':
+            case 'non-negative-int':
+            case 'non-positive-int':
+                return Type::int();
             default:
                 return $this->handleUnknownType($node);
         }

--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -352,6 +352,27 @@ class Reflector
             );
         }
 
+        if (count($returnTypes) === 0 && $reflection->getDocComment()) {
+            $mixins = $this->getDocBlockParser()->parseMixins($reflection->getDocComment());
+
+            foreach ($mixins as $mixin) {
+                if (! $mixin instanceof ClassType) {
+                    continue;
+                }
+
+                try {
+                    $mixinReflection = $this->reflectClass($mixin->value);
+                } catch (Throwable $e) {
+                    continue;
+                }
+
+                if ($mixinReflection->hasMethod($method)) {
+                    array_push($returnTypes, ...$this->methodReturnType($mixin->value, $method, $node));
+                    break;
+                }
+            }
+        }
+
         if (count($returnTypes) > 0) {
             return $returnTypes;
         }

--- a/tests/Unit/Resolvers/StaticCallTest.php
+++ b/tests/Unit/Resolvers/StaticCallTest.php
@@ -6,6 +6,7 @@ use Laravel\Surveyor\Analyzer\AnalyzedCache;
 use Laravel\Surveyor\Analyzer\Analyzer;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 use Laravel\Surveyor\Types\Entities\ResourceResponse;
+use Laravel\Surveyor\Types\IntType;
 use Laravel\Surveyor\Types\UnionType;
 
 uses()->group('integration');
@@ -121,6 +122,34 @@ class CollectionController
         // Illuminate\Http\Resources\Json\AnonymousResourceCollection return
         // shouldn't get unioned in alongside it.
         expect($returnType)->toBeInstanceOf(ResourceResponse::class);
+
+        unlink($fixture);
+    });
+});
+
+describe('Eloquent builder chains', function () {
+    it('resolves Model::query()->count() to int', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use App\\Models\\User;
+
+class UserController
+{
+    public function index()
+    {
+        $count = User::query()->count();
+
+        return $count;
+    }
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        $returnType = $result->getMethod('index')->returnType();
+
+        expect($returnType)->toBeInstanceOf(IntType::class);
 
         unlink($fixture);
     });


### PR DESCRIPTION
Two related issues caused Eloquent builder chain methods like `count()` to resolve as `mixed`. First, `Eloquent\Builder` doesn't define `count()` directly — it relies on `@mixin \Illuminate\Database\Query\Builder` — but the reflector never followed `@mixin` tags when a method wasn't found. Second, even once the method is found on `Query\Builder`, its return type of `int<0, max>` wasn't recognized since `GenericTypeNode` had no handling for integer range types.

This adds `@mixin` fallback lookup to `methodReturnType` and teaches `GenericTypeNode` to resolve `int<0, max>`, `positive-int`, and friends as `int`.
