### PR TITLE
Resolve Inertia special prop types (defer, optional, lazy, always, merge)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,12 @@
         "spatie/php-structure-discoverer": "^2.3"
     },
     "require-dev": {
+        "inertiajs/inertia-laravel": "^3.1",
+        "laravel/pint": "^1.22",
         "mockery/mockery": "^1.6",
         "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^3.0",
-        "phpstan/phpstan": "^2.1",
-        "laravel/pint": "^1.22"
+        "phpstan/phpstan": "^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2188d8bed227575266a9cf6fface0c0e",
+    "content-hash": "99afe07671077366cef7de79c04a6a3e",
     "packages": [
         {
             "name": "brick/math",
@@ -6471,6 +6471,79 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
             "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "inertiajs/inertia-laravel",
+            "version": "v3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/inertiajs/inertia-laravel.git",
+                "reference": "f588ce4a5beb25d166f4e372bac0c7f46a4f52ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/inertiajs/inertia-laravel/zipball/f588ce4a5beb25d166f4e372bac0c7f46a4f52ac",
+                "reference": "f588ce4a5beb25d166f4e372bac0c7f46a4f52ac",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laravel/framework": "^11.0|^12.0|^13.0",
+                "php": "^8.2.0",
+                "symfony/console": "^7.0|^8.0"
+            },
+            "conflict": {
+                "laravel/boost": "<2.2.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.2",
+                "larastan/larastan": "^3.0",
+                "laravel/pint": "^1.16",
+                "mockery/mockery": "^1.3.3",
+                "orchestra/testbench": "^9.2|^10.0|^11.0",
+                "phpunit/phpunit": "^11.5|^12.0",
+                "roave/security-advisories": "dev-master"
+            },
+            "suggest": {
+                "ext-pcntl": "Recommended when running the Inertia SSR server via the `inertia:start-ssr` artisan command."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Inertia\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "./helpers.php"
+                ],
+                "psr-4": {
+                    "Inertia\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Reinink",
+                    "email": "jonathan@reinink.ca",
+                    "homepage": "https://reinink.ca"
+                }
+            ],
+            "description": "The Laravel adapter for Inertia.js.",
+            "keywords": [
+                "inertia",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/inertiajs/inertia-laravel/issues",
+                "source": "https://github.com/inertiajs/inertia-laravel/tree/v3.1.0"
+            },
+            "time": "2026-04-30T15:30:29+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",

--- a/release.sh
+++ b/release.sh
@@ -64,6 +64,27 @@ echo ""
 echo "Current version: v$CURRENT_VERSION"
 echo ""
 
+echo "Merged PRs since v$CURRENT_VERSION:"
+echo ""
+
+if [ "$CURRENT_VERSION" = "0.0.0" ]; then
+    COMMITS=$(git log --oneline)
+else
+    COMMITS=$(git log "v$CURRENT_VERSION"..HEAD --oneline)
+fi
+
+PR_NUMBERS=$(echo "$COMMITS" | grep -oE '#[0-9]+' | tr -d '#' | sort -rn)
+
+if [ -z "$PR_NUMBERS" ]; then
+    echo "  No PRs found since last release."
+else
+    for pr in $PR_NUMBERS; do
+        gh pr view "$pr" --json number,title,url | jq -r '"  #\(.number) — \(.title) (\(.url))"' 2>/dev/null || true
+    done
+fi
+
+echo ""
+
 echo "Select version bump type:"
 echo "1) patch (bug fixes)"
 echo "2) minor (new features)"

--- a/src/NodeResolvers/Expr/StaticCall.php
+++ b/src/NodeResolvers/Expr/StaticCall.php
@@ -129,6 +129,13 @@ class StaticCall extends AbstractResolver
             return false;
         }
 
+        if (
+            $class->value === 'Inertia\Inertia'
+            && in_array($method, ['defer', 'optional', 'lazy', 'always', 'merge'], true)
+        ) {
+            return true;
+        }
+
         // Resource ::collection() / ::make() entity types fully describe the return shape;
         // unioning the documented AnonymousResourceCollection only adds noise.
         if (! in_array($method, ['collection', 'make'], true)) {
@@ -163,18 +170,34 @@ class StaticCall extends AbstractResolver
 
     protected function handleInertiaEntity(string $method, Node\Expr\StaticCall $node): array
     {
-        if ($method !== 'render') {
-            return [];
+        if ($method === 'render') {
+            $args = array_map(fn ($arg) => $this->from($arg->value), $node->getArgs());
+
+            return [
+                new InertiaRender(
+                    $args[0]->value,
+                    $args[1] ?? Type::arrayShape(Type::string(), Type::mixed()),
+                ),
+            ];
         }
 
-        $args = array_map(fn ($arg) => $this->from($arg->value), $node->getArgs());
+        if (in_array($method, ['defer', 'optional', 'lazy', 'always', 'merge'], true)) {
+            $args = $node->getArgs();
 
-        return [
-            new InertiaRender(
-                $args[0]->value,
-                $args[1] ?? Type::arrayShape(Type::string(), Type::mixed()),
-            ),
-        ];
+            if (empty($args)) {
+                return [Type::mixed()];
+            }
+
+            $type = $this->resolveClosureReturnType($args[0]->value) ?? Type::mixed();
+
+            if (in_array($method, ['defer', 'optional', 'lazy'], true)) {
+                $type->optional();
+            }
+
+            return [$type];
+        }
+
+        return [];
     }
 
     protected function handleViewEntity(string $method, Node\Expr\StaticCall $node): array

--- a/tests/Unit/Resolvers/InertiaStaticCallTest.php
+++ b/tests/Unit/Resolvers/InertiaStaticCallTest.php
@@ -1,0 +1,186 @@
+<?php
+
+use Laravel\Surveyor\Analyzed\ClassLikeResult;
+use Laravel\Surveyor\Analyzer\AnalyzedCache;
+use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Types\ClassType;
+use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
+use Laravel\Surveyor\Types\Entities\InertiaRender;
+use Laravel\Surveyor\Types\IntType;
+use Laravel\Surveyor\Types\StringType;
+use Laravel\Surveyor\Types\UnionType;
+
+uses()->group('integration');
+
+beforeEach(function () {
+    AnalyzedCache::clear();
+});
+
+afterEach(function () {
+    AnalyzedCache::clear();
+});
+
+function findInertiaRender(TypeContract $type): ?InertiaRender
+{
+    if ($type instanceof InertiaRender) {
+        return $type;
+    }
+
+    if ($type instanceof UnionType) {
+        foreach ($type->types as $inner) {
+            if ($inner instanceof InertiaRender) {
+                return $inner;
+            }
+        }
+    }
+
+    return null;
+}
+
+describe('Inertia special prop types', function () {
+    it('resolves Inertia::defer() to the callback return type', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use Inertia\\Inertia;
+use App\\Models\\User;
+
+class DashboardController
+{
+    public function index()
+    {
+        return Inertia::render(\'Dashboard\', [
+            \'users\' => Inertia::defer(fn () => User::all()),
+        ]);
+    }
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        expect($result)->toBeInstanceOf(ClassLikeResult::class);
+
+        $render = findInertiaRender($result->getMethod('index')->returnType());
+
+        expect($render)->not->toBeNull();
+        expect($render->data->value['users'])->toBeInstanceOf(ClassType::class);
+        expect($render->data->value['users']->value)->toBe('Illuminate\\Database\\Eloquent\\Collection');
+        expect($render->data->value['users']->isOptional())->toBeTrue();
+
+        unlink($fixture);
+    });
+
+    it('resolves Inertia::optional() to the callback return type marked optional', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use Inertia\\Inertia;
+
+class DashboardController
+{
+    public function index()
+    {
+        return Inertia::render(\'Dashboard\', [
+            \'name\' => Inertia::optional(fn () => \'hello\'),
+        ]);
+    }
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        $render = findInertiaRender($result->getMethod('index')->returnType());
+
+        expect($render)->not->toBeNull();
+        expect($render->data->value['name'])->toBeInstanceOf(StringType::class);
+        expect($render->data->value['name']->isOptional())->toBeTrue();
+
+        unlink($fixture);
+    });
+
+    it('resolves Inertia::lazy() to the callback return type marked optional', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use Inertia\\Inertia;
+
+class DashboardController
+{
+    public function index()
+    {
+        return Inertia::render(\'Dashboard\', [
+            \'count\' => Inertia::lazy(fn () => 42),
+        ]);
+    }
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        $render = findInertiaRender($result->getMethod('index')->returnType());
+
+        expect($render)->not->toBeNull();
+        expect($render->data->value['count'])->toBeInstanceOf(IntType::class);
+        expect($render->data->value['count']->isOptional())->toBeTrue();
+
+        unlink($fixture);
+    });
+
+    it('resolves Inertia::always() to the callback return type', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use Inertia\\Inertia;
+
+class DashboardController
+{
+    public function index()
+    {
+        return Inertia::render(\'Dashboard\', [
+            \'name\' => Inertia::always(fn () => \'hello\'),
+        ]);
+    }
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        $render = findInertiaRender($result->getMethod('index')->returnType());
+
+        expect($render)->not->toBeNull();
+        expect($render->data->value['name'])->toBeInstanceOf(StringType::class);
+        expect($render->data->value['name']->isOptional())->toBeFalse();
+
+        unlink($fixture);
+    });
+
+    it('resolves Inertia::merge() to the callback return type', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use Inertia\\Inertia;
+use App\\Models\\User;
+
+class DashboardController
+{
+    public function index()
+    {
+        return Inertia::render(\'Dashboard\', [
+            \'users\' => Inertia::merge(fn () => User::all()),
+        ]);
+    }
+}');
+
+        $analyzer = app(Analyzer::class);
+        $result = $analyzer->analyze($fixture)->result();
+
+        $render = findInertiaRender($result->getMethod('index')->returnType());
+
+        expect($render)->not->toBeNull();
+        expect($render->data->value['users'])->toBeInstanceOf(ClassType::class);
+        expect($render->data->value['users']->value)->toBe('Illuminate\\Database\\Eloquent\\Collection');
+        expect($render->data->value['users']->isOptional())->toBeFalse();
+
+        unlink($fixture);
+    });
+});


### PR DESCRIPTION
Inertia's prop wrapper methods — `defer`, `optional`, `lazy`, `always`, and `merge` — previously fell through to reflection, which returned the wrapper class (`DeferProp`, `OptionalProp`, etc.) rather than the actual prop type. Surveyor now resolves the callback's return type directly for each of these, so consumers like ranger see the real inner type instead of the wrapper.

`defer`, `optional`, and `lazy` are marked as optional since the prop may not be present in the initial response. `always` and `merge` are left as required.

Adds `inertiajs/inertia-laravel` as a dev dependency so `Inertia\Inertia` is a known class during test analysis — in real projects it would already be installed.
