### PR TITLE
Fix PHP warning when a cached dependency file no longer exists

### DIFF
--- a/src/Analyzer/AnalyzedCache.php
+++ b/src/Analyzer/AnalyzedCache.php
@@ -151,7 +151,9 @@ class AnalyzedCache
         }
 
         foreach ($data['dependencies'] as $dependency) {
-            if ($dependency['mtime'] !== filemtime($dependency['path'])) {
+            $currentMtime = file_exists($dependency['path']) ? filemtime($dependency['path']) : null;
+
+            if ($dependency['mtime'] !== $currentMtime) {
                 static::invalidate($dependency['path']);
                 static::invalidate($path);
 

--- a/tests/Unit/Analyzer/AnalyzedCacheTest.php
+++ b/tests/Unit/Analyzer/AnalyzedCacheTest.php
@@ -485,6 +485,33 @@ describe('dependency tracking', function () {
         cleanupCacheDir($dir);
     });
 
+    it('invalidates cache when dependency file is deleted', function () {
+        $dir = createCacheDir();
+        AnalyzedCache::enableDiskCache($dir);
+
+        $mainFixture = createTestClassFixture('MainClass', 'public function main() {}');
+        $depFixture = createTestClassFixture('DepClass', 'public function dep() {}');
+
+        AnalyzedCache::addDependency($depFixture);
+
+        $scope = new Scope;
+        $scope->setPath($mainFixture);
+        AnalyzedCache::add($mainFixture, $scope);
+
+        AnalyzedCache::clearMemory();
+
+        expect(AnalyzedCache::get($mainFixture))->not->toBeNull();
+
+        unlink($depFixture);
+
+        AnalyzedCache::clearMemory();
+
+        expect(AnalyzedCache::get($mainFixture))->toBeNull();
+
+        unlink($mainFixture);
+        cleanupCacheDir($dir);
+    });
+
     it('invalidates cache when dependency file changes', function () {
         $dir = createCacheDir();
         AnalyzedCache::enableDiskCache($dir);


### PR DESCRIPTION
When validating disk-cached dependencies, `filemtime()` was called directly on the dependency path without checking if the file exists. If a dependency had been deleted since the cache was written, PHP would emit a warning and return `false`, which technically triggered cache invalidation but with noisy output.

The fix mirrors the pattern already used when writing the cache: treat a missing file as a `null` mtime. Since dependencies are only stored when their mtime is non-null, a missing file will never match the stored mtime and the cache is invalidated cleanly.
