### PR TITLE
fix: resolve array cast to ArrayType instead of ArrayShapeType

### DIFF
--- a/src/Analyzer/ModelAnalyzer.php
+++ b/src/Analyzer/ModelAnalyzer.php
@@ -161,7 +161,8 @@ class ModelAnalyzer
     protected function resolveCast(string $cast): TypeContract
     {
         $result = match ($cast) {
-            'json', 'encrypted:json', 'encrypted:array', 'encrypted:collection', 'array', 'encrypted:object' => Type::arrayShape(Type::mixed(), Type::mixed()),
+            'json', 'encrypted:json', 'encrypted:object' => Type::arrayShape(Type::mixed(), Type::mixed()),
+            'array', 'encrypted:array', 'encrypted:collection' => Type::array([]),
             'timestamp', 'int', 'integer', 'float' => Type::int(),
             'attribute', 'encrypted' => Type::mixed(),
             'hashed', 'date', 'datetime', 'immutable_date', 'immutable_datetime',  'string' => Type::string(),

--- a/src/Analyzer/ModelAnalyzer.php
+++ b/src/Analyzer/ModelAnalyzer.php
@@ -33,10 +33,17 @@ class ModelAnalyzer
         $info = $this->modelInspector->inspect($model);
 
         foreach ($info['attributes'] as $attribute) {
-            $type = $this->resolveAttributeType($attribute, $model, $result);
+            // An annotation is a deliberate statement about the attribute, so it beats
+            // anything we infer from the cast or the column. Its nullability is part of
+            // that statement, so the column's nullability is not applied over it.
+            $type = $this->annotatedType($result, $attribute['name']);
 
-            if (isset($attribute['nullable'])) {
-                $type->nullable($attribute['nullable']);
+            if ($type === null) {
+                $type = $this->resolveAttributeType($attribute, $model, $result);
+
+                if (isset($attribute['nullable'])) {
+                    $type->nullable($attribute['nullable']);
+                }
             }
 
             $result->addProperty(new PropertyResult($attribute['name'], $type, modelAttribute: true));
@@ -76,6 +83,23 @@ class ModelAnalyzer
 
             $result->addMethod($methodResult);
         }
+    }
+
+    protected function annotatedType(ClassLikeResult $result, string $name): ?TypeContract
+    {
+        if (! $result->hasProperty($name)) {
+            return null;
+        }
+
+        $property = $result->getProperty($name);
+
+        // Eloquent's own protected properties ($casts, $fillable, ...) carry doc blocks
+        // of their own and must never be mistaken for an attribute annotation.
+        if (! $property->fromDocBlock || $property->visibility !== 'public') {
+            return null;
+        }
+
+        return $property->type;
     }
 
     protected function resolveAttributeType(array $attribute, string $model, ClassLikeResult $result): TypeContract
@@ -161,8 +185,17 @@ class ModelAnalyzer
     protected function resolveCast(string $cast): TypeContract
     {
         $result = match ($cast) {
-            'json', 'encrypted:json', 'encrypted:object' => Type::arrayShape(Type::mixed(), Type::mixed()),
-            'array', 'encrypted:array', 'encrypted:collection' => Type::array([]),
+            // These all decode JSON, which yields either a list or a keyed map. Picking one
+            // is a guess that types half of all usage wrongly, so both are offered and the
+            // consumer narrows. An annotation on the model beats this entirely.
+            'array', 'encrypted:array',
+            'json', 'json:unicode', 'encrypted:json',
+            'collection', 'encrypted:collection' => Type::union(
+                Type::arrayShape(Type::int(), Type::mixed()),
+                Type::arrayShape(Type::mixed(), Type::mixed()),
+            ),
+            // Decoded without associative mode, so always an object.
+            'object', 'encrypted:object' => Type::arrayShape(Type::mixed(), Type::mixed()),
             'timestamp', 'int', 'integer', 'float' => Type::int(),
             'attribute', 'encrypted' => Type::mixed(),
             'hashed', 'date', 'datetime', 'immutable_date', 'immutable_datetime',  'string' => Type::string(),

--- a/tests/Unit/Analyzer/ModelAnalyzerTest.php
+++ b/tests/Unit/Analyzer/ModelAnalyzerTest.php
@@ -1,12 +1,21 @@
 <?php
 
+use App\Models\Annotation;
 use App\Models\Post;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelInspector;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 use Laravel\Surveyor\Analyzer\AnalyzedCache;
 use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Analyzer\ModelAnalyzer;
+use Laravel\Surveyor\Types\ArrayShapeType;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\ClassType;
+use Laravel\Surveyor\Types\IntType;
+use Laravel\Surveyor\Types\MixedType;
+use Laravel\Surveyor\Types\StringType;
+use Laravel\Surveyor\Types\UnionType;
 
 uses()->group('integration');
 
@@ -372,69 +381,86 @@ describe('ModelInspector integration', function () {
 });
 
 describe('ModelAnalyzer resolveCast', function () {
-    it('resolves array cast to ArrayType', function () {
-        $analyzer = app(\Laravel\Surveyor\Analyzer\ModelAnalyzer::class);
-        $reflection = new \ReflectionClass($analyzer);
-        $method = $reflection->getMethod('resolveCast');
-        $method->setAccessible(true);
+    $resolve = function (string $cast) {
+        $analyzer = app(ModelAnalyzer::class);
+        $method = (new ReflectionClass($analyzer))->getMethod('resolveCast');
 
-        $result = $method->invoke($analyzer, 'array');
+        return $method->invoke($analyzer, $cast);
+    };
 
-        expect($result)->toBeInstanceOf(ArrayType::class);
+    it('offers both a list and a keyed map for JSON decoding casts', function (string $cast) use ($resolve) {
+        $result = $resolve($cast);
+
+        expect($result)->toBeInstanceOf(UnionType::class);
+        expect($result->types)->toHaveCount(2);
+
+        // A list, keyed by int...
+        expect($result->types[0])->toBeInstanceOf(ArrayShapeType::class);
+        expect($result->types[0]->keyType)->toBeInstanceOf(IntType::class);
+        expect($result->types[0]->valueType)->toBeInstanceOf(MixedType::class);
+
+        // ...or a map, keyed by anything.
+        expect($result->types[1])->toBeInstanceOf(ArrayShapeType::class);
+        expect($result->types[1]->keyType)->toBeInstanceOf(MixedType::class);
+        expect($result->types[1]->valueType)->toBeInstanceOf(MixedType::class);
+    })->with([
+        'array',
+        'encrypted:array',
+        'json',
+        'json:unicode',
+        'encrypted:json',
+        'collection',
+        'encrypted:collection',
+    ]);
+
+    it('resolves object casts to a keyed map only', function (string $cast) use ($resolve) {
+        $result = $resolve($cast);
+
+        expect($result)->toBeInstanceOf(ArrayShapeType::class);
+        expect($result->keyType)->toBeInstanceOf(MixedType::class);
+        expect($result->valueType)->toBeInstanceOf(MixedType::class);
+    })->with(['object', 'encrypted:object']);
+});
+
+describe('ModelAnalyzer attribute annotations', function () {
+    beforeEach(function () {
+        Schema::create('annotations', function (Blueprint $table) {
+            $table->id();
+            $table->json('languages');
+            $table->json('scores');
+            $table->json('meta')->nullable();
+        });
     });
 
-    it('resolves encrypted:array cast to ArrayType', function () {
-        $analyzer = app(\Laravel\Surveyor\Analyzer\ModelAnalyzer::class);
-        $reflection = new \ReflectionClass($analyzer);
-        $method = $reflection->getMethod('resolveCast');
-        $method->setAccessible(true);
-
-        $result = $method->invoke($analyzer, 'encrypted:array');
-
-        expect($result)->toBeInstanceOf(ArrayType::class);
+    afterEach(function () {
+        Schema::drop('annotations');
     });
 
-    it('resolves encrypted:collection cast to ArrayType', function () {
-        $analyzer = app(\Laravel\Surveyor\Analyzer\ModelAnalyzer::class);
-        $reflection = new \ReflectionClass($analyzer);
-        $method = $reflection->getMethod('resolveCast');
-        $method->setAccessible(true);
+    it('keeps an annotated type instead of the one inferred from the cast', function () {
+        $result = app(Analyzer::class)->analyzeClass(Annotation::class)->result();
 
-        $result = $method->invoke($analyzer, 'encrypted:collection');
+        $languages = $result->getProperty('languages')->type;
 
-        expect($result)->toBeInstanceOf(ArrayType::class);
+        expect($languages)->toBeInstanceOf(ArrayShapeType::class);
+        expect($languages->keyType)->toBeInstanceOf(IntType::class);
+        expect($languages->valueType)->toBeInstanceOf(StringType::class);
+
+        $scores = $result->getProperty('scores')->type;
+
+        expect($scores)->toBeInstanceOf(ArrayShapeType::class);
+        expect($scores->keyType)->toBeInstanceOf(StringType::class);
+        expect($scores->valueType)->toBeInstanceOf(IntType::class);
     });
 
-    it('resolves json cast to ArrayShapeType', function () {
-        $analyzer = app(\Laravel\Surveyor\Analyzer\ModelAnalyzer::class);
-        $reflection = new \ReflectionClass($analyzer);
-        $method = $reflection->getMethod('resolveCast');
-        $method->setAccessible(true);
+    it('still flags an annotated attribute as a model attribute', function () {
+        $result = app(Analyzer::class)->analyzeClass(Annotation::class)->result();
 
-        $result = $method->invoke($analyzer, 'json');
-
-        expect($result)->toBeInstanceOf(\Laravel\Surveyor\Types\ArrayShapeType::class);
+        expect($result->getProperty('languages')->modelAttribute)->toBeTrue();
     });
 
-    it('resolves encrypted:json cast to ArrayShapeType', function () {
-        $analyzer = app(\Laravel\Surveyor\Analyzer\ModelAnalyzer::class);
-        $reflection = new \ReflectionClass($analyzer);
-        $method = $reflection->getMethod('resolveCast');
-        $method->setAccessible(true);
+    it('falls back to the cast when there is no annotation', function () {
+        $result = app(Analyzer::class)->analyzeClass(Annotation::class)->result();
 
-        $result = $method->invoke($analyzer, 'encrypted:json');
-
-        expect($result)->toBeInstanceOf(\Laravel\Surveyor\Types\ArrayShapeType::class);
-    });
-
-    it('resolves encrypted:object cast to ArrayShapeType', function () {
-        $analyzer = app(\Laravel\Surveyor\Analyzer\ModelAnalyzer::class);
-        $reflection = new \ReflectionClass($analyzer);
-        $method = $reflection->getMethod('resolveCast');
-        $method->setAccessible(true);
-
-        $result = $method->invoke($analyzer, 'encrypted:object');
-
-        expect($result)->toBeInstanceOf(\Laravel\Surveyor\Types\ArrayShapeType::class);
+        expect($result->getProperty('meta')->type)->toBeInstanceOf(UnionType::class);
     });
 });

--- a/tests/Unit/Analyzer/ModelAnalyzerTest.php
+++ b/tests/Unit/Analyzer/ModelAnalyzerTest.php
@@ -370,3 +370,71 @@ describe('ModelInspector integration', function () {
         expect($relations->get('posts')['related'])->toBe(Post::class);
     });
 });
+
+describe('ModelAnalyzer resolveCast', function () {
+    it('resolves array cast to ArrayType', function () {
+        $analyzer = app(\Laravel\Surveyor\Analyzer\ModelAnalyzer::class);
+        $reflection = new \ReflectionClass($analyzer);
+        $method = $reflection->getMethod('resolveCast');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($analyzer, 'array');
+
+        expect($result)->toBeInstanceOf(ArrayType::class);
+    });
+
+    it('resolves encrypted:array cast to ArrayType', function () {
+        $analyzer = app(\Laravel\Surveyor\Analyzer\ModelAnalyzer::class);
+        $reflection = new \ReflectionClass($analyzer);
+        $method = $reflection->getMethod('resolveCast');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($analyzer, 'encrypted:array');
+
+        expect($result)->toBeInstanceOf(ArrayType::class);
+    });
+
+    it('resolves encrypted:collection cast to ArrayType', function () {
+        $analyzer = app(\Laravel\Surveyor\Analyzer\ModelAnalyzer::class);
+        $reflection = new \ReflectionClass($analyzer);
+        $method = $reflection->getMethod('resolveCast');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($analyzer, 'encrypted:collection');
+
+        expect($result)->toBeInstanceOf(ArrayType::class);
+    });
+
+    it('resolves json cast to ArrayShapeType', function () {
+        $analyzer = app(\Laravel\Surveyor\Analyzer\ModelAnalyzer::class);
+        $reflection = new \ReflectionClass($analyzer);
+        $method = $reflection->getMethod('resolveCast');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($analyzer, 'json');
+
+        expect($result)->toBeInstanceOf(\Laravel\Surveyor\Types\ArrayShapeType::class);
+    });
+
+    it('resolves encrypted:json cast to ArrayShapeType', function () {
+        $analyzer = app(\Laravel\Surveyor\Analyzer\ModelAnalyzer::class);
+        $reflection = new \ReflectionClass($analyzer);
+        $method = $reflection->getMethod('resolveCast');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($analyzer, 'encrypted:json');
+
+        expect($result)->toBeInstanceOf(\Laravel\Surveyor\Types\ArrayShapeType::class);
+    });
+
+    it('resolves encrypted:object cast to ArrayShapeType', function () {
+        $analyzer = app(\Laravel\Surveyor\Analyzer\ModelAnalyzer::class);
+        $reflection = new \ReflectionClass($analyzer);
+        $method = $reflection->getMethod('resolveCast');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($analyzer, 'encrypted:object');
+
+        expect($result)->toBeInstanceOf(\Laravel\Surveyor\Types\ArrayShapeType::class);
+    });
+});

--- a/workbench/app/Models/Annotation.php
+++ b/workbench/app/Models/Annotation.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property list<string> $languages
+ * @property array<string, int> $scores
+ */
+class Annotation extends Model
+{
+    protected function casts(): array
+    {
+        return [
+            'languages' => 'array',
+            'scores' => 'array',
+            'meta' => 'array',
+        ];
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes issue #59 where model casts with `'array'`, `'encrypted:array'`, or `'encrypted:collection'` were incorrectly generating `Record<string, unknown>` instead of `unknown[]` in TypeScript.

## Root Cause

In `ModelAnalyzer::resolveCast()`, the `'array'` cast was grouped with `'json'` and `'object'` casts in a single match arm, causing it to create an `ArrayShapeType` instead of an `ArrayType`.

## Fix

Split the match arm to handle `'array'`, `'encrypted:array'`, and `'encrypted:collection'` separately, returning `Type::array([])` instead of `Type::arrayShape(Type::mixed(), Type::mixed())`.

## Changes

- **`src/Analyzer/ModelAnalyzer.php`**: Split match arm for array vs json/object casts
- **`tests/Unit/Analyzer/ModelAnalyzerTest.php`**: Added 6 tests verifying correct cast resolution

## Test Results

- All 26 ModelAnalyzer tests pass
- All 75 Type tests pass

## Type Conversion Impact

| Cast Type | Before | After |
|-----------|--------|-------|
| `'array'` | `Record<string, unknown>` | `unknown[]` |
| `'encrypted:array'` | `Record<string, unknown>` | `unknown[]` |
| `'encrypted:collection'` | `Record<string, unknown>` | `unknown[]` |
| `'json'` | `Record<string, unknown>` | `Record<string, unknown>` (no change) |
| `'encrypted:json'` | `Record<string, unknown>` | `Record<string, unknown>` (no change) |
| `'encrypted:object'` | `Record<string, unknown>` | `Record<string, unknown>` (no change) |

Closes #59
