### PR TITLE
Fix analyzer state when given an empty path

### DIFF
--- a/src/Analyzer/AnalyzedCache.php
+++ b/src/Analyzer/AnalyzedCache.php
@@ -212,6 +212,7 @@ class AnalyzedCache
         static::$cached = [];
         static::$fileTimes = [];
         static::$inProgress = [];
+        static::$dependencies = [];
     }
 
     public static function clear(): void

--- a/src/Analyzer/Analyzer.php
+++ b/src/Analyzer/Analyzer.php
@@ -37,6 +37,9 @@ class Analyzer
         if ($path === '') {
             Debug::log('⚠️ No path provided to analyze.');
 
+            $this->analyzing--;
+            $this->analyzed = new Scope;
+
             return $this;
         }
 

--- a/src/Analyzer/Analyzer.php
+++ b/src/Analyzer/Analyzer.php
@@ -21,11 +21,19 @@ class Analyzer
 
     public function analyzeClass(string $className)
     {
-        return $this->analyze((new ReflectionClass($className))->getFileName());
+        return $this->analyze((new ReflectionClass($className))->getFileName() ?: '');
     }
 
     public function analyze(string $path)
     {
+        if ($path === '') {
+            Debug::log('⚠️ No path provided to analyze.');
+
+            $this->analyzed = new Scope;
+
+            return $this;
+        }
+
         $shortPath = str_replace($_ENV['HOME'] ?? '', '~', $path);
 
         if ($this->analyzing > 0) {
@@ -33,15 +41,6 @@ class Analyzer
         }
 
         $this->analyzing++;
-
-        if ($path === '') {
-            Debug::log('⚠️ No path provided to analyze.');
-
-            $this->analyzing--;
-            $this->analyzed = new Scope;
-
-            return $this;
-        }
 
         Debug::addPath($path);
 
@@ -57,6 +56,12 @@ class Analyzer
 
         if (AnalyzedCache::isInProgress($path)) {
             Debug::log("⏳ Waiting for analysis to complete: {$shortPath}");
+
+            // The in-progress scope isn't available yet, so anything still held
+            // in $analyzed belongs to an unrelated file.
+            $this->analyzed = new Scope;
+
+            $this->analyzing--;
 
             return $this;
         }
@@ -89,6 +94,6 @@ class Analyzer
 
     public function result()
     {
-        return $this->analyzed->result();
+        return $this->analyzed()?->result();
     }
 }

--- a/tests/Unit/AnalyzerTest.php
+++ b/tests/Unit/AnalyzerTest.php
@@ -18,6 +18,8 @@ uses()->group('integration');
 
 beforeEach(function () {
     AnalyzedCache::clear();
+
+    app()->forgetInstance(Analyzer::class);
 });
 
 afterEach(function () {
@@ -622,5 +624,75 @@ class TestController
         expect($scope->namespace())->toBe('App\\Http\\Controllers');
 
         unlink($fixture);
+    });
+});
+
+describe('empty path handling', function () {
+    it('does not leak the analyzing counter when given an empty path', function () {
+        $analyzer = app(Analyzer::class);
+
+        $analyzer->analyze('');
+
+        $analyzing = new ReflectionProperty(Analyzer::class, 'analyzing');
+
+        expect($analyzing->getValue($analyzer))->toBe(0);
+    });
+
+    it('does not treat an unrelated later call as nested after an empty path leak', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+class AfterEmptyPath
+{
+}');
+
+        $analyzer = app(Analyzer::class);
+
+        $analyzer->analyze('');
+        $analyzer->analyze($fixture);
+
+        $dependencies = new ReflectionProperty(AnalyzedCache::class, 'dependencies');
+
+        expect($dependencies->getValue())->toBe([]);
+
+        unlink($fixture);
+    });
+
+    it('does not return stale data from a previous file when given an empty path', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+class BeforeEmptyPath
+{
+}');
+
+        $analyzer = app(Analyzer::class);
+        $analyzer->analyze($fixture);
+
+        $analyzer->analyze('');
+
+        expect($analyzer->result())->toBeNull();
+
+        unlink($fixture);
+    });
+
+    it('does not throw when result() is called after an empty path on a fresh analyzer', function () {
+        $analyzer = app(Analyzer::class);
+
+        $analyzer->analyze('');
+
+        expect($analyzer->result())->toBeNull();
+    });
+
+    it('handles internal classes whose file cannot be resolved', function () {
+        $analyzer = app(Analyzer::class);
+
+        $analyzer->analyzeClass(DateTime::class);
+
+        expect($analyzer->result())->toBeNull();
+
+        $analyzing = new ReflectionProperty(Analyzer::class, 'analyzing');
+
+        expect($analyzing->getValue($analyzer))->toBe(0);
     });
 });

--- a/tests/Unit/AnalyzerTest.php
+++ b/tests/Unit/AnalyzerTest.php
@@ -695,4 +695,91 @@ class BeforeEmptyPath
 
         expect($analyzing->getValue($analyzer))->toBe(0);
     });
+
+    it('does not leak the analyzing counter when an internal class is reached mid-analysis', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use DateTime;
+
+class ReachesInternalClass
+{
+    public function handle(): array
+    {
+        $date = new DateTime();
+
+        return ["year" => $date->format("Y")];
+    }
+}');
+
+        $analyzer = app(Analyzer::class);
+
+        $analyzer->analyze($fixture);
+
+        $analyzing = new ReflectionProperty(Analyzer::class, 'analyzing');
+
+        expect($analyzing->getValue($analyzer))->toBe(0);
+
+        unlink($fixture);
+    });
+});
+
+describe('in progress path handling', function () {
+    it('does not leak the analyzing counter when two files reference each other', function () {
+        $directory = sys_get_temp_dir().'/surveyor_circular_'.uniqid();
+
+        mkdir($directory);
+
+        file_put_contents($directory.'/CircularA.php', '<?php
+namespace App\Circular;
+
+class CircularA
+{
+    public function toB(): CircularB
+    {
+        return new CircularB();
+    }
+
+    public function handle(): array
+    {
+        return ["label" => (new CircularB())->toA()->label()];
+    }
+
+    public function label(): string
+    {
+        return "a";
+    }
+}');
+
+        file_put_contents($directory.'/CircularB.php', '<?php
+namespace App\Circular;
+
+class CircularB
+{
+    public function toA(): CircularA
+    {
+        return new CircularA();
+    }
+
+    public function label(): string
+    {
+        return "b";
+    }
+}');
+
+        require_once $directory.'/CircularA.php';
+        require_once $directory.'/CircularB.php';
+
+        $analyzer = app(Analyzer::class);
+
+        $analyzer->analyze($directory.'/CircularA.php');
+
+        $analyzing = new ReflectionProperty(Analyzer::class, 'analyzing');
+
+        expect($analyzing->getValue($analyzer))->toBe(0);
+
+        unlink($directory.'/CircularA.php');
+        unlink($directory.'/CircularB.php');
+        rmdir($directory);
+    });
 });


### PR DESCRIPTION
 When `analyze()` receives an empty path the early return leaves the analysis counter incremented and the analyzed scope uninitialized. This can incorrectly mark subsequent analyses as nested dependencies and cause `result()` to fail.

This change decrements the counter and assigns a fresh `Scope` before returning, ensuring `result()` safely returns `null` and subsequent analyses start with the correct state. It also updates `AnalyzedCache::clear()` to reset tracked dependencies so cache resets do not retain stale analysis state.
