### PR TITLE
Plethora of performance improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 .github/          export-ignore
 .gitignore        export-ignore
 .vscode/          export-ignore
+benchmarks/       export-ignore
 composer.lock     export-ignore
 phpstan.neon.dist export-ignore
 phpunit.xml       export-ignore

--- a/benchmarks/bench.php
+++ b/benchmarks/bench.php
@@ -1,0 +1,291 @@
+<?php
+
+/**
+ * Wayfinder / Surveyor benchmark harness.
+ *
+ * Measures `php artisan wayfinder:generate` in two modes:
+ *
+ *   fresh — cache emptied and `--fresh` passed, so everything is parsed and
+ *           analyzed again. This is the Surveyor number.
+ *   warm  — cache filled by a discarded priming run, then measured. This is
+ *           the cache-read and codegen number.
+ *
+ * Results are written to benchmarks/results/<label>.json.
+ *
+ * Usage:
+ *   php surveyor/benchmarks/bench.php --label=baseline
+ *   php surveyor/benchmarks/bench.php --label=after-my-change --mode=fresh --runs=5
+ *
+ * Options:
+ *   --label       name for this measurement, used as the result filename
+ *   --mode        fresh | warm | both (default: both)
+ *   --runs        measured iterations per mode (default: 3)
+ *   --warmups     discarded iterations before measuring (default: 1)
+ *   --prime       0 to skip priming the output directory if it is already primed
+ *   --app         path to the Laravel application
+ *   --out         directory to generate into
+ *   --cache-dir   Wayfinder cache directory to clear between fresh runs
+ *
+ * Only compare warm numbers measured back to back in the same session. A warm
+ * run reads hundreds of megabytes of cache, so its timing depends on the OS page
+ * cache, which this script does not control, and the same code can measure 7s or
+ * 13s. A tight standard deviation does not help: a cold page cache is slow on
+ * every iteration, so the number looks steady while still being wrong.
+ *
+ * To find which part of the code is slow, add temporary timers and measure
+ * exclusive time, meaning elapsed time minus time spent inside nested timers.
+ * Inclusive timings mislead here, because analysis recurses across files, so
+ * whatever sits nearest the root looks like the bottleneck. Keep temporary
+ * timers off the hottest paths, and remove them before trusting a total.
+ */
+final class Sample
+{
+    public function __construct(
+        public readonly float $seconds,
+        public readonly ?int $peakBytes,
+    ) {}
+}
+
+final class Benchmark
+{
+    public function __construct(
+        private readonly string $appPath,
+        private readonly string $outputPath,
+        private readonly string $cacheDirectory,
+        private readonly int $runs,
+        private readonly int $warmups,
+    ) {}
+
+    /**
+     * Generate once up front so every measured run finds the output directory
+     * in the same already-populated state.
+     */
+    public function primeOutputDirectory(): void
+    {
+        echo "Priming output directory...\n";
+
+        $this->clearCache();
+        $this->generate(fresh: true);
+    }
+
+    /**
+     * @return array{samples: list<float>, timing: array<string, float>, peak_rss_bytes: int|null}
+     */
+    public function measure(string $mode): array
+    {
+        echo "\n=== {$mode} ===\n";
+
+        $fresh = $mode === 'fresh';
+
+        if (! $fresh) {
+            // A run without --fresh fills the disk cache. Discard it so every
+            // measured run reads a full cache.
+            echo "Priming disk cache...\n";
+
+            $this->clearCache();
+            $this->generate(fresh: false);
+        }
+
+        for ($i = 0; $i < $this->warmups; $i++) {
+            $this->print('warmup', $this->iterate($fresh));
+        }
+
+        /** @var list<Sample> $samples */
+        $samples = [];
+
+        for ($i = 1; $i <= $this->runs; $i++) {
+            $this->print("run {$i}", $samples[] = $this->iterate($fresh));
+        }
+
+        $seconds = array_map(fn (Sample $sample) => $sample->seconds, $samples);
+        $peaks = array_filter(array_map(fn (Sample $sample) => $sample->peakBytes, $samples));
+
+        $timing = $this->summarise($seconds);
+
+        printf(
+            "  ── min %.2fs  median %.2fs  mean %.2fs  stddev %.2fs\n",
+            $timing['min'],
+            $timing['median'],
+            $timing['mean'],
+            $timing['stddev'],
+        );
+
+        return [
+            'samples' => $seconds,
+            'timing' => $timing,
+            'peak_rss_bytes' => $peaks === [] ? null : min($peaks),
+        ];
+    }
+
+    private function iterate(bool $fresh): Sample
+    {
+        if ($fresh) {
+            $this->clearCache();
+        }
+
+        return $this->generate($fresh);
+    }
+
+    /**
+     * Peak memory comes from `/usr/bin/time -l`, because a child process's peak
+     * is not visible from this one.
+     */
+    private function generate(bool $fresh): Sample
+    {
+        $command = sprintf(
+            '/usr/bin/time -l %s artisan wayfinder:generate --path=%s %s',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($this->outputPath),
+            $fresh ? '--fresh' : '',
+        );
+
+        $descriptors = [
+            ['file', '/dev/null', 'r'],
+            ['file', '/dev/null', 'w'],
+            ['pipe', 'w'],
+        ];
+
+        $startedAt = hrtime(true);
+
+        $process = proc_open($command, $descriptors, $pipes, $this->appPath);
+
+        if (! is_resource($process)) {
+            $this->fail('Could not start the generate command.');
+        }
+
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[2]);
+
+        $exitCode = proc_close($process);
+        $elapsed = (hrtime(true) - $startedAt) / 1e9;
+
+        if ($exitCode !== 0) {
+            $this->fail("The generate command exited with {$exitCode}:\n{$stderr}");
+        }
+
+        $peakBytes = preg_match('/(\d+)\s+maximum resident set size/', $stderr, $matches)
+            ? (int) $matches[1]
+            : null;
+
+        return new Sample($elapsed, $peakBytes);
+    }
+
+    private function clearCache(): void
+    {
+        foreach (glob($this->cacheDirectory.'/*.cache') ?: [] as $file) {
+            unlink($file);
+        }
+    }
+
+    /**
+     * @param  list<float>  $seconds
+     * @return array<string, float>
+     */
+    private function summarise(array $seconds): array
+    {
+        sort($seconds);
+
+        $count = count($seconds);
+        $mean = array_sum($seconds) / $count;
+
+        $median = $count % 2 === 1
+            ? $seconds[intdiv($count, 2)]
+            : ($seconds[$count / 2 - 1] + $seconds[$count / 2]) / 2;
+
+        $variance = $count > 1
+            ? array_sum(array_map(fn (float $value) => ($value - $mean) ** 2, $seconds)) / ($count - 1)
+            : 0.0;
+
+        return [
+            'min' => $seconds[0],
+            'max' => $seconds[$count - 1],
+            'median' => $median,
+            'mean' => $mean,
+            'stddev' => sqrt($variance),
+        ];
+    }
+
+    private function print(string $label, Sample $sample): void
+    {
+        printf(
+            "  %-12s %6.2fs%s\n",
+            $label,
+            $sample->seconds,
+            $sample->peakBytes === null ? '' : sprintf('   %6.0f MB', $sample->peakBytes / 1024 / 1024),
+        );
+    }
+
+    private function fail(string $message): never
+    {
+        fwrite(STDERR, $message.PHP_EOL);
+
+        exit(1);
+    }
+}
+
+$options = getopt('', ['app::', 'label::', 'runs::', 'warmups::', 'mode::', 'out::', 'cache-dir::', 'prime::']);
+
+$appPath = realpath($options['app'] ?? dirname(__DIR__, 2));
+
+if ($appPath === false || ! is_file($appPath.'/artisan')) {
+    fwrite(STDERR, "Could not locate a Laravel application. Pass --app=/path/to/app\n");
+
+    exit(1);
+}
+
+$label = $options['label'] ?? 'run';
+$outputPath = $options['out'] ?? sys_get_temp_dir().'/wayfinder-bench-out';
+$resultsDirectory = __DIR__.'/results';
+
+$modes = match ($options['mode'] ?? 'both') {
+    'both' => ['fresh', 'warm'],
+    'fresh' => ['fresh'],
+    'warm' => ['warm'],
+    default => null,
+};
+
+if ($modes === null) {
+    fwrite(STDERR, "Unknown --mode. Expected one of: fresh, warm, both.\n");
+
+    exit(1);
+}
+
+if (! is_dir($resultsDirectory)) {
+    mkdir($resultsDirectory, 0755, true);
+}
+
+if (! is_dir($outputPath)) {
+    mkdir($outputPath, 0755, true);
+}
+
+$benchmark = new Benchmark(
+    appPath: $appPath,
+    outputPath: $outputPath,
+    cacheDirectory: $options['cache-dir'] ?? $appPath.'/storage/wayfinder-cache',
+    runs: max(1, (int) ($options['runs'] ?? 3)),
+    warmups: max(0, (int) ($options['warmups'] ?? 1)),
+);
+
+if (($options['prime'] ?? '1') === '0') {
+    echo "Skipping output priming (--prime=0).\n";
+} else {
+    $benchmark->primeOutputDirectory();
+}
+
+$results = [];
+
+foreach ($modes as $mode) {
+    $results[$mode] = $benchmark->measure($mode);
+}
+
+$resultsFile = $resultsDirectory.'/'.$label.'.json';
+
+file_put_contents($resultsFile, json_encode([
+    'label' => $label,
+    'recorded_at' => date('c'),
+    'php_version' => PHP_VERSION,
+    'app_path' => $appPath,
+    'results' => $results,
+], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+echo "\nWrote {$resultsFile}\n";

--- a/benchmarks/results/.gitignore
+++ b/benchmarks/results/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/Analysis/Scope.php
+++ b/src/Analysis/Scope.php
@@ -245,7 +245,7 @@ class Scope
         $this->stateTracker->setThis($entityName);
 
         if (! $quietly) {
-            Debug::log('🔬 Scope: '.$entityName, level: 2);
+            Debug::log('🔬 Scope: '.$entityName, level: Debug::VERBOSE);
         }
     }
 
@@ -389,7 +389,7 @@ class Scope
         $this->methodName = $methodName;
 
         if (! $quietly) {
-            Debug::log("🔬 Scope: {$this->entityName}::{$methodName}", level: 2);
+            Debug::log("🔬 Scope: {$this->entityName}::{$methodName}", level: Debug::VERBOSE);
         }
     }
 

--- a/src/Analysis/Scope.php
+++ b/src/Analysis/Scope.php
@@ -429,8 +429,8 @@ class Scope
 
     public function startConditionAnalysis($quiet = false): void
     {
-        if (! $quiet) {
-            Debug::log(fn () => '🟢 Starting condition analysis: '.$this->path(), level: 3);
+        if (! $quiet && Debug::$logLevel >= Debug::TRACE) {
+            Debug::log('🟢 Starting condition analysis: '.$this->path());
         }
 
         $this->analyzingCondition = true;
@@ -438,8 +438,8 @@ class Scope
 
     public function endConditionAnalysis($quiet = false): void
     {
-        if (! $quiet) {
-            Debug::log(fn () => '🔴 Ending condition analysis: '.$this->path(), level: 3);
+        if (! $quiet && Debug::$logLevel >= Debug::TRACE) {
+            Debug::log('🔴 Ending condition analysis: '.$this->path());
         }
 
         $this->analyzingCondition = false;
@@ -451,7 +451,9 @@ class Scope
             return;
         }
 
-        Debug::log(fn () => '🟡 Pausing condition analysis: '.$this->path(), level: 3);
+        if (Debug::$logLevel >= Debug::TRACE) {
+            Debug::log('🟡 Pausing condition analysis: '.$this->path());
+        }
 
         $this->analyzingConditionPaused = true;
         $this->endConditionAnalysis(true);
@@ -463,7 +465,9 @@ class Scope
             return;
         }
 
-        Debug::log(fn () => '🟠 Resuming condition analysis: '.$this->path(), level: 3);
+        if (Debug::$logLevel >= Debug::TRACE) {
+            Debug::log('🟠 Resuming condition analysis: '.$this->path());
+        }
 
         $this->analyzingConditionPaused = false;
         $this->startConditionAnalysis(true);

--- a/src/Analysis/Scope.php
+++ b/src/Analysis/Scope.php
@@ -430,7 +430,7 @@ class Scope
     public function startConditionAnalysis($quiet = false): void
     {
         if (! $quiet) {
-            Debug::log('🟢 Starting condition analysis: '.$this->path(), level: 3);
+            Debug::log(fn () => '🟢 Starting condition analysis: '.$this->path(), level: 3);
         }
 
         $this->analyzingCondition = true;
@@ -439,7 +439,7 @@ class Scope
     public function endConditionAnalysis($quiet = false): void
     {
         if (! $quiet) {
-            Debug::log('🔴 Ending condition analysis: '.$this->path(), level: 3);
+            Debug::log(fn () => '🔴 Ending condition analysis: '.$this->path(), level: 3);
         }
 
         $this->analyzingCondition = false;
@@ -451,7 +451,7 @@ class Scope
             return;
         }
 
-        Debug::log('🟡 Pausing condition analysis: '.$this->path(), level: 3);
+        Debug::log(fn () => '🟡 Pausing condition analysis: '.$this->path(), level: 3);
 
         $this->analyzingConditionPaused = true;
         $this->endConditionAnalysis(true);
@@ -463,7 +463,7 @@ class Scope
             return;
         }
 
-        Debug::log('🟠 Resuming condition analysis: '.$this->path(), level: 3);
+        Debug::log(fn () => '🟠 Resuming condition analysis: '.$this->path(), level: 3);
 
         $this->analyzingConditionPaused = false;
         $this->startConditionAnalysis(true);

--- a/src/Analyzer/AnalyzedCache.php
+++ b/src/Analyzer/AnalyzedCache.php
@@ -20,7 +20,13 @@ class AnalyzedCache
 
     protected static bool $persistToDisk = false;
 
+    /** @var array<string, true> */
     protected static array $dependencies = [];
+
+    /** @var array<string, int|null> */
+    protected static array $modifiedTimes = [];
+
+    protected static bool $fileTimesFrozen = false;
 
     protected static ?string $key = null;
 
@@ -31,7 +37,41 @@ class AnalyzedCache
 
     public static function addDependency(string $path): void
     {
-        static::$dependencies[] = $path;
+        // Keyed by path to avoid duplicates. The full list is written into
+        // every cache file, and it only grows.
+        static::$dependencies[$path] = true;
+    }
+
+    /**
+     * Look up each file's modification time once and reuse it, instead of
+     * stat'ing on every cache lookup.
+     *
+     * Off by default. Only turn it on when files cannot change while the
+     * process runs, such as in a one-shot command. With it on, editing a file
+     * mid-run will not invalidate its cache entry.
+     */
+    public static function freezeFileTimes(bool $frozen = true): void
+    {
+        static::$fileTimesFrozen = $frozen;
+
+        if (! $frozen) {
+            static::$modifiedTimes = [];
+        }
+    }
+
+    protected static function modifiedTime(string $path): ?int
+    {
+        if (static::$fileTimesFrozen && array_key_exists($path, static::$modifiedTimes)) {
+            return static::$modifiedTimes[$path];
+        }
+
+        $modifiedTime = file_exists($path) ? filemtime($path) : null;
+
+        if (static::$fileTimesFrozen) {
+            static::$modifiedTimes[$path] = $modifiedTime;
+        }
+
+        return $modifiedTime;
     }
 
     public static function setCacheDirectory(string $directory): void
@@ -71,7 +111,7 @@ class AnalyzedCache
 
     public static function add(string $path, Scope $analyzed): void
     {
-        $mtime = file_exists($path) ? filemtime($path) : null;
+        $mtime = static::modifiedTime($path);
 
         static::$cached[$path] = $analyzed;
         static::$fileTimes[$path] = $mtime;
@@ -84,11 +124,11 @@ class AnalyzedCache
 
     public static function get(string $path): ?Scope
     {
-        if (! file_exists($path)) {
+        $currentModifiedTime = static::modifiedTime($path);
+
+        if ($currentModifiedTime === null) {
             return null;
         }
-
-        $currentModifiedTime = filemtime($path);
 
         return self::tryFromMemory($path, $currentModifiedTime)
             ?? self::tryFromDisk($path, $currentModifiedTime)
@@ -151,7 +191,7 @@ class AnalyzedCache
         }
 
         foreach ($data['dependencies'] as $dependency) {
-            $currentMtime = file_exists($dependency['path']) ? filemtime($dependency['path']) : null;
+            $currentMtime = static::modifiedTime($dependency['path']);
 
             if ($dependency['mtime'] !== $currentMtime) {
                 static::invalidate($dependency['path']);
@@ -213,6 +253,7 @@ class AnalyzedCache
         static::$fileTimes = [];
         static::$inProgress = [];
         static::$dependencies = [];
+        static::$modifiedTimes = [];
     }
 
     public static function clear(): void
@@ -250,8 +291,8 @@ class AnalyzedCache
             'mtime' => $mtime,
             'dependencies' => array_values(array_filter(array_map(fn ($dep) => [
                 'path' => $dep,
-                'mtime' => file_exists($dep) ? filemtime($dep) : null,
-            ], array_values(array_unique(self::$dependencies))), fn ($dep) => $dep['mtime'] !== null)),
+                'mtime' => static::modifiedTime($dep),
+            ], array_keys(self::$dependencies)), fn ($dep) => $dep['mtime'] !== null)),
             'scope' => $analyzed,
         ];
 

--- a/src/Analyzer/AnalyzedCache.php
+++ b/src/Analyzer/AnalyzedCache.php
@@ -42,23 +42,6 @@ class AnalyzedCache
         static::$dependencies[$path] = true;
     }
 
-    /**
-     * Look up each file's modification time once and reuse it, instead of
-     * stat'ing on every cache lookup.
-     *
-     * Off by default. Only turn it on when files cannot change while the
-     * process runs, such as in a one-shot command. With it on, editing a file
-     * mid-run will not invalidate its cache entry.
-     */
-    public static function freezeFileTimes(bool $frozen = true): void
-    {
-        static::$fileTimesFrozen = $frozen;
-
-        if (! $frozen) {
-            static::$modifiedTimes = [];
-        }
-    }
-
     protected static function modifiedTime(string $path): ?int
     {
         if (static::$fileTimesFrozen && array_key_exists($path, static::$modifiedTimes)) {

--- a/src/Analyzer/AnalyzedCache.php
+++ b/src/Analyzer/AnalyzedCache.php
@@ -42,6 +42,23 @@ class AnalyzedCache
         static::$dependencies[$path] = true;
     }
 
+    /**
+     * Look up each file's modification time once and reuse it, instead of
+     * stat'ing on every cache lookup.
+     *
+     * Off by default. Only turn it on when files cannot change while the
+     * process runs, such as in a one-shot command. With it on, editing a file
+     * mid-run will not invalidate its cache entry.
+     */
+    public static function freezeFileTimes(bool $frozen = true): void
+    {
+        static::$fileTimesFrozen = $frozen;
+
+        if (! $frozen) {
+            static::$modifiedTimes = [];
+        }
+    }
+
     protected static function modifiedTime(string $path): ?int
     {
         if (static::$fileTimesFrozen && array_key_exists($path, static::$modifiedTimes)) {

--- a/src/Analyzer/Analyzer.php
+++ b/src/Analyzer/Analyzer.php
@@ -34,8 +34,6 @@ class Analyzer
             return $this;
         }
 
-        $shortPath = str_replace($_ENV['HOME'] ?? '', '~', $path);
-
         if ($this->analyzing > 0) {
             AnalyzedCache::addDependency($path);
         }
@@ -45,7 +43,7 @@ class Analyzer
         Debug::addPath($path);
 
         if ($cached = AnalyzedCache::get($path)) {
-            Debug::log("🎁 Using cached analysis: {$shortPath}");
+            Debug::log(static fn () => '🎁 Using cached analysis: '.self::shortPath($path));
 
             $this->analyzed = $cached;
 
@@ -55,7 +53,7 @@ class Analyzer
         }
 
         if (AnalyzedCache::isInProgress($path)) {
-            Debug::log("⏳ Waiting for analysis to complete: {$shortPath}");
+            Debug::log(static fn () => '⏳ Waiting for analysis to complete: '.self::shortPath($path));
 
             // The in-progress scope isn't available yet, so anything still held
             // in $analyzed belongs to an unrelated file.
@@ -68,7 +66,7 @@ class Analyzer
 
         AnalyzedCache::inProgress($path);
 
-        Debug::log("🧠 Analyzing: {$shortPath}");
+        Debug::log(static fn () => '🧠 Analyzing: '.self::shortPath($path));
 
         $analyzed = $this->parser->parse(file_get_contents($path), $path);
 
@@ -85,6 +83,11 @@ class Analyzer
         $this->analyzing--;
 
         return $this;
+    }
+
+    protected static function shortPath(string $path): string
+    {
+        return str_replace($_ENV['HOME'] ?? '', '~', $path);
     }
 
     public function analyzed(): ?Scope

--- a/src/Debug/Debug.php
+++ b/src/Debug/Debug.php
@@ -13,6 +13,8 @@ class Debug
 {
     public const LOG = 1;
 
+    public const VERBOSE = 2;
+
     public const TRACE = 3;
 
     public static $dump = false;

--- a/src/Debug/Debug.php
+++ b/src/Debug/Debug.php
@@ -11,6 +11,10 @@ use function Laravel\Prompts\table;
 
 class Debug
 {
+    public const LOG = 1;
+
+    public const TRACE = 3;
+
     public static $dump = false;
 
     public static $throw = false;
@@ -81,7 +85,7 @@ class Debug
         return $timings;
     }
 
-    public static function error(Throwable $e, $message, $data = null, $level = 1)
+    public static function error(Throwable $e, $message, $data = null, $level = self::LOG)
     {
         self::log(
             static fn () => '🚨 '.$message.' ['.$e->getMessage().'] at '.$e->getFile().':'.$e->getLine(),
@@ -108,7 +112,7 @@ class Debug
      * @param  Closure():mixed|string|mixed  $message
      * @param  Closure():mixed|array|object|string|null  $data
      */
-    public static function log($message, $data = null, $level = 1)
+    public static function log($message, $data = null, $level = self::LOG)
     {
         if (self::$logLevel < $level) {
             return;
@@ -213,7 +217,7 @@ class Debug
     public static function increaseDepth()
     {
         // Depth is only used to indent log output, so skip it when logging is off.
-        if (self::$logLevel < 1 || ($path = self::activePath()) === null) {
+        if (self::$logLevel < self::LOG || ($path = self::activePath()) === null) {
             return;
         }
 
@@ -222,7 +226,7 @@ class Debug
 
     public static function decreaseDepth()
     {
-        if (self::$logLevel < 1 || ($path = self::activePath()) === null) {
+        if (self::$logLevel < self::LOG || ($path = self::activePath()) === null) {
             return;
         }
 

--- a/src/Debug/Debug.php
+++ b/src/Debug/Debug.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Surveyor\Debug;
 
+use Closure;
 use PhpParser\NodeAbstract;
 use Throwable;
 
@@ -82,7 +83,11 @@ class Debug
 
     public static function error(Throwable $e, $message, $data = null, $level = 1)
     {
-        self::log('🚨 '.$message.' ['.$e->getMessage().'] at '.$e->getFile().':'.$e->getLine(), $data, $level);
+        self::log(
+            static fn () => '🚨 '.$message.' ['.$e->getMessage().'] at '.$e->getFile().':'.$e->getLine(),
+            $data,
+            $level,
+        );
     }
 
     public static function throwOr(Throwable $e, callable $callback)
@@ -94,10 +99,27 @@ class Debug
         return $callback();
     }
 
+    /**
+     * Write a debug line.
+     *
+     * $message and $data may be closures, which are only called if the log
+     * level passes. Use that form when building the arguments costs anything.
+     *
+     * @param  Closure():mixed|string|mixed  $message
+     * @param  Closure():mixed|array|object|string|null  $data
+     */
     public static function log($message, $data = null, $level = 1)
     {
         if (self::$logLevel < $level) {
             return;
+        }
+
+        if ($message instanceof Closure) {
+            $message = $message();
+        }
+
+        if ($data instanceof Closure) {
+            $data = $data();
         }
 
         $indent = str_repeat('    ', self::depth());
@@ -164,14 +186,14 @@ class Debug
 
     protected static function activePath()
     {
-        $paths = array_keys(self::$paths);
-
-        return end($paths) ?? null;
+        return array_key_last(self::$paths);
     }
 
     public static function depth()
     {
-        return self::$depths[self::activePath()] ?? 0;
+        $path = self::activePath();
+
+        return $path === null ? 0 : (self::$depths[$path] ?? 0);
     }
 
     public static function reportMemoryUsage($print = true)
@@ -190,12 +212,21 @@ class Debug
 
     public static function increaseDepth()
     {
-        self::$depths[self::activePath()]++;
+        // Depth is only used to indent log output, so skip it when logging is off.
+        if (self::$logLevel < 1 || ($path = self::activePath()) === null) {
+            return;
+        }
+
+        self::$depths[$path] = (self::$depths[$path] ?? 0) + 1;
     }
 
     public static function decreaseDepth()
     {
-        self::$depths[self::activePath()] = max(0, self::$depths[self::activePath()] - 1);
+        if (self::$logLevel < 1 || ($path = self::activePath()) === null) {
+            return;
+        }
+
+        self::$depths[$path] = max(0, (self::$depths[$path] ?? 0) - 1);
     }
 
     public static function throw(Throwable $e)

--- a/src/DocBlockResolvers/AbstractResolver.php
+++ b/src/DocBlockResolvers/AbstractResolver.php
@@ -24,7 +24,9 @@ abstract class AbstractResolver
 
     protected function from(Node $node)
     {
-        Debug::log(static fn () => '📄 Resolving DocBlock: '.get_class($node), level: 3);
+        if (Debug::$logLevel >= Debug::TRACE) {
+            Debug::log('📄 Resolving DocBlock: '.get_class($node));
+        }
 
         return $this->typeResolver
             ->setParsed($this->parsed)

--- a/src/DocBlockResolvers/AbstractResolver.php
+++ b/src/DocBlockResolvers/AbstractResolver.php
@@ -24,7 +24,7 @@ abstract class AbstractResolver
 
     protected function from(Node $node)
     {
-        Debug::log('📄 Resolving DocBlock: '.get_class($node), level: 3);
+        Debug::log(static fn () => '📄 Resolving DocBlock: '.get_class($node), level: 3);
 
         return $this->typeResolver
             ->setParsed($this->parsed)

--- a/src/NodeResolvers/AbstractResolver.php
+++ b/src/NodeResolvers/AbstractResolver.php
@@ -40,7 +40,7 @@ abstract class AbstractResolver
 
     protected function from(NodeAbstract $node)
     {
-        Debug::log('🔍 Analyzing Node: '.$node->getType(), level: 3);
+        Debug::log(static fn () => '🔍 Analyzing Node: '.$node->getType(), level: 3);
 
         return $this->resolver->from($node, $this->scope);
     }

--- a/src/NodeResolvers/AbstractResolver.php
+++ b/src/NodeResolvers/AbstractResolver.php
@@ -40,7 +40,9 @@ abstract class AbstractResolver
 
     protected function from(NodeAbstract $node)
     {
-        Debug::log(static fn () => '🔍 Analyzing Node: '.$node->getType(), level: 3);
+        if (Debug::$logLevel >= Debug::TRACE) {
+            Debug::log('🔍 Analyzing Node: '.$node->getType());
+        }
 
         return $this->resolver->from($node, $this->scope);
     }

--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -409,7 +409,6 @@ class Reflector
                         break;
                     }
                 }
-
             }
 
             if (count($returnTypes) > 0) {

--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -22,7 +22,6 @@ use Laravel\Surveyor\Types\UnionType;
 use PhpParser\Node;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Stmt\TraitUse;
-use PhpParser\NodeFinder;
 use ReflectionClass;
 use ReflectionFunction;
 use ReflectionIntersectionType;
@@ -44,6 +43,9 @@ class Reflector
     protected array $cachedFunctions = [];
 
     protected array $cachedMacros = [];
+
+    /** @var array<string, list<string>> */
+    protected array $cachedTraitUseDocBlocks = [];
 
     public function setScope(Scope $scope)
     {
@@ -359,16 +361,18 @@ class Reflector
                     $returnTypes[] = $this->returnType($methodReflection->getReturnType());
                 }
 
-                if ($methodReflection->getDocComment()) {
+                $methodDocComment = $methodReflection->getDocComment();
+
+                if ($methodDocComment) {
                     array_push(
                         $returnTypes,
-                        ...$this->parseDocBlock($methodReflection->getDocComment()),
+                        ...$this->parseDocBlock($methodDocComment),
                     );
                 }
 
                 array_push(
                     $returnTypes,
-                    ...$this->parseDocBlock($methodReflection->getDocComment(), $node)
+                    ...$this->parseDocBlock($methodDocComment, $node)
                 );
             }
 
@@ -405,6 +409,7 @@ class Reflector
                         break;
                     }
                 }
+
             }
 
             if (count($returnTypes) > 0) {
@@ -482,28 +487,10 @@ class Reflector
      */
     protected function parseTraitUseBindings(ReflectionClass $reflection, string $fileName): array
     {
-        try {
-            $nodes = $this->getParser()->parseFile($fileName);
-        } catch (Throwable $e) {
-            return [];
-        }
-
         $bindings = [];
-        $nodeFinder = new NodeFinder;
 
-        /** @var TraitUse[] $traitUseNodes */
-        $traitUseNodes = $nodeFinder->findInstanceOf($nodes, TraitUse::class);
-
-        foreach ($traitUseNodes as $traitUseNode) {
-            $docComment = $traitUseNode->getDocComment();
-
-            if (! $docComment || ! str_contains($docComment->getText(), '@use')) {
-                continue;
-            }
-
-            $useTypes = $this->getDocBlockParser()->parseUsesTags($docComment->getText());
-
-            foreach ($useTypes as $useType) {
+        foreach ($this->traitUseDocBlocks($fileName) as $docBlock) {
+            foreach ($this->getDocBlockParser()->parseUsesTags($docBlock) as $useType) {
                 if (! $useType instanceof ClassType || count($useType->genericTypes()) === 0) {
                     continue;
                 }
@@ -513,6 +500,58 @@ class Reflector
         }
 
         return $bindings;
+    }
+
+    /**
+     * The `@use` doc blocks on a file's trait use statements.
+     *
+     * Parsing the file to find them is the slowest part of resolving a generic
+     * method call, and a file's doc blocks cannot change during a run, so they
+     * are cached. Resolving the tags is not cached, because that depends on the
+     * scope in use at the time.
+     *
+     * @return list<string>
+     */
+    protected function traitUseDocBlocks(string $fileName): array
+    {
+        if (isset($this->cachedTraitUseDocBlocks[$fileName])) {
+            return $this->cachedTraitUseDocBlocks[$fileName];
+        }
+
+        return $this->cachedTraitUseDocBlocks[$fileName] = $this->findTraitUseDocBlocks($fileName);
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function findTraitUseDocBlocks(string $fileName): array
+    {
+        try {
+            $nodes = $this->getParser()->parseFile($fileName);
+        } catch (Throwable $e) {
+            return [];
+        }
+
+        $docBlocks = [];
+
+        /** @var TraitUse[] $traitUseNodes */
+        $traitUseNodes = $this->getParser()->nodeFinder()->findInstanceOf($nodes, TraitUse::class);
+
+        foreach ($traitUseNodes as $traitUseNode) {
+            $docComment = $traitUseNode->getDocComment();
+
+            if (! $docComment) {
+                continue;
+            }
+
+            $text = $docComment->getText();
+
+            if (str_contains($text, '@use')) {
+                $docBlocks[] = $text;
+            }
+        }
+
+        return $docBlocks;
     }
 
     protected function resolveMacro(ReflectionClass $reflection, string $macroName): array

--- a/src/Resolvers/NodeResolver.php
+++ b/src/Resolvers/NodeResolver.php
@@ -96,7 +96,9 @@ class NodeResolver
     {
         $className = $this->getClassName($node);
 
-        Debug::log(static fn () => '🧐 Resolving Node: '.$className.' '.$node->getStartLine(), level: 3);
+        if (Debug::$logLevel >= Debug::TRACE) {
+            Debug::log('🧐 Resolving Node: '.$className.' '.$node->getStartLine());
+        }
 
         return new $className($this, $this->docBlockParser, $this->reflector);
     }

--- a/src/Resolvers/NodeResolver.php
+++ b/src/Resolvers/NodeResolver.php
@@ -10,11 +10,15 @@ use Laravel\Surveyor\Parser\DocBlockParser;
 use Laravel\Surveyor\Reflector\Reflector;
 use Laravel\Surveyor\Types\Type;
 use PhpParser\NodeAbstract;
+use ReflectionMethod;
 use Throwable;
 
 class NodeResolver
 {
     protected array $resolved = [];
+
+    /** @var array<class-string<AbstractResolver>, bool> */
+    protected array $hasExitBehaviour = [];
 
     public function __construct(
         protected Container $app,
@@ -55,6 +59,15 @@ class NodeResolver
      */
     public function exitNode(NodeAbstract $node, Scope $scope)
     {
+        $className = $this->getClassName($node);
+
+        // Almost every resolver inherits onExit() and exitScope() unchanged, so
+        // exiting does nothing but hand back the same scope. Building one just
+        // to find that out costs an object on every node in the tree.
+        if (! ($this->hasExitBehaviour[$className] ??= $this->resolverHasExitBehaviour($className))) {
+            return $scope;
+        }
+
         $resolver = $this->resolveClassInstance($node);
 
         $resolver->setScope($scope);
@@ -64,13 +77,26 @@ class NodeResolver
     }
 
     /**
+     * @param  class-string<AbstractResolver>  $className
+     */
+    protected function resolverHasExitBehaviour(string $className): bool
+    {
+        try {
+            return (new ReflectionMethod($className, 'onExit'))->class !== AbstractResolver::class
+                || (new ReflectionMethod($className, 'exitScope'))->class !== AbstractResolver::class;
+        } catch (Throwable) {
+            return true;
+        }
+    }
+
+    /**
      * @return AbstractResolver
      */
     protected function resolveClassInstance(NodeAbstract $node)
     {
         $className = $this->getClassName($node);
 
-        Debug::log('🧐 Resolving Node: '.$className.' '.$node->getStartLine(), level: 3);
+        Debug::log(static fn () => '🧐 Resolving Node: '.$className.' '.$node->getStartLine(), level: 3);
 
         return new $className($this, $this->docBlockParser, $this->reflector);
     }

--- a/src/Result/StateTrackerItem.php
+++ b/src/Result/StateTrackerItem.php
@@ -139,11 +139,13 @@ class StateTrackerItem
         $activeSnapshot = $this->getActiveSnapshotKey();
 
         if ($activeSnapshot) {
-            Debug::log('🆕 Updating snapshot', static fn () => [
-                'name' => $name,
-                'changes' => $variableState->toArray(),
-                'snapshot' => $activeSnapshot,
-            ], level: 3);
+            if (Debug::$logLevel >= Debug::TRACE) {
+                Debug::log('🆕 Updating snapshot', [
+                    'name' => $name,
+                    'changes' => $variableState->toArray(),
+                    'snapshot' => $activeSnapshot,
+                ]);
+            }
 
             $this->snapshots[$activeSnapshot][$name] ??= [];
 
@@ -167,10 +169,12 @@ class StateTrackerItem
 
             $this->snapshots[$activeSnapshot][$name][] = $variableState;
         } else {
-            Debug::log('🆕 Updating variable', static fn () => [
-                'name' => $name,
-                'changes' => $variableState,
-            ], level: 3);
+            if (Debug::$logLevel >= Debug::TRACE) {
+                Debug::log('🆕 Updating variable', [
+                    'name' => $name,
+                    'changes' => $variableState,
+                ]);
+            }
 
             $this->variables[$name] ??= [];
 
@@ -318,10 +322,12 @@ class StateTrackerItem
     {
         $key = $this->getSnapshotKey($node);
 
-        Debug::log('📸 Starting snapshot', static fn () => [
-            'key' => $key,
-            'node' => get_class($node),
-        ], level: 3);
+        if (Debug::$logLevel >= Debug::TRACE) {
+            Debug::log('📸 Starting snapshot', [
+                'key' => $key,
+                'node' => get_class($node),
+            ]);
+        }
 
         $this->snapshots[$key] = [];
         $this->activeSnapshots[] = $key;
@@ -333,11 +339,13 @@ class StateTrackerItem
 
         $changed = $this->snapshots[$key] ?? [];
 
-        Debug::log('📷 Ending snapshot', static fn () => [
-            'key' => $key,
-            'node' => get_class($node),
-            'changed' => $changed,
-        ], level: 3);
+        if (Debug::$logLevel >= Debug::TRACE) {
+            Debug::log('📷 Ending snapshot', [
+                'key' => $key,
+                'node' => get_class($node),
+                'changed' => $changed,
+            ]);
+        }
 
         array_pop($this->activeSnapshots);
         unset($this->snapshots[$key]);

--- a/src/Result/StateTrackerItem.php
+++ b/src/Result/StateTrackerItem.php
@@ -139,7 +139,7 @@ class StateTrackerItem
         $activeSnapshot = $this->getActiveSnapshotKey();
 
         if ($activeSnapshot) {
-            Debug::log('🆕 Updating snapshot', [
+            Debug::log('🆕 Updating snapshot', static fn () => [
                 'name' => $name,
                 'changes' => $variableState->toArray(),
                 'snapshot' => $activeSnapshot,
@@ -167,7 +167,7 @@ class StateTrackerItem
 
             $this->snapshots[$activeSnapshot][$name][] = $variableState;
         } else {
-            Debug::log('🆕 Updating variable', [
+            Debug::log('🆕 Updating variable', static fn () => [
                 'name' => $name,
                 'changes' => $variableState,
             ], level: 3);
@@ -318,7 +318,7 @@ class StateTrackerItem
     {
         $key = $this->getSnapshotKey($node);
 
-        Debug::log('📸 Starting snapshot', [
+        Debug::log('📸 Starting snapshot', static fn () => [
             'key' => $key,
             'node' => get_class($node),
         ], level: 3);
@@ -333,7 +333,7 @@ class StateTrackerItem
 
         $changed = $this->snapshots[$key] ?? [];
 
-        Debug::log('📷 Ending snapshot', [
+        Debug::log('📷 Ending snapshot', static fn () => [
             'key' => $key,
             'node' => get_class($node),
             'changed' => $changed,

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Surveyor\Types;
 
-use Illuminate\Support\Collection;
 use Laravel\Surveyor\Result\VariableState;
 use Laravel\Surveyor\Support\Util;
 use Laravel\Surveyor\Types\Contracts\CollapsibleType;
@@ -175,43 +174,98 @@ class Type
         return self::string($value);
     }
 
-    protected static function flattenUnion(array $args): Collection
+    /**
+     * Flatten nested unions into $types, dropping empty members and unwrapping
+     * variable states.
+     *
+     * @param  list<Contracts\Type|VariableState|null>  $args
+     * @param  list<Contracts\Type>  $types
+     */
+    protected static function flattenUnion(array $args, array &$types): void
     {
-        return collect($args)->flatMap(
-            fn ($type) => ($type instanceof UnionType)
-                ? self::flattenUnion($type->types)
-                : [$type]
-        );
+        foreach ($args as $type) {
+            if ($type instanceof UnionType) {
+                self::flattenUnion($type->types, $types);
+
+                continue;
+            }
+
+            if (! $type) {
+                continue;
+            }
+
+            $types[] = $type instanceof VariableState ? $type->type() : $type;
+        }
     }
 
     public static function union(...$args): Contracts\Type
     {
-        $args = self::flattenUnion($args)
-            ->filter()
-            ->map(fn ($type) => match (true) {
-                $type instanceof VariableState => $type->type(),
-                default => $type,
-            })
-            ->unique(fn ($type) => $type->toString())
-            ->values();
+        $types = [];
 
-        $nullType = $args->filter(fn ($type) => $type instanceof NullType);
+        self::flattenUnion($args, $types);
 
-        if ($nullType->isNotEmpty()) {
-            $args = $args->map(fn ($type) => $type instanceof NullType ? null : $type->nullable())->filter()->values();
+        if ($types === []) {
+            return self::mixed();
         }
 
-        // Remove types that have a more specific counterpart
-        $args = $args->filter(fn ($type) => ! $args->contains(
-            fn ($otherType) => $type !== $otherType && $otherType->isMoreSpecificThan($type)
-        ))->values();
+        // With one member there is nothing to de-duplicate or compare, so skip
+        // toString(), which is a json_encode() for array and union types.
+        if (count($types) === 1) {
+            return ($types[0] instanceof MixedType || $types[0] instanceof NullType)
+                ? self::mixed()
+                : $types[0];
+        }
 
-        $args = $args->filter(fn ($type) => ! $type instanceof MixedType)->values();
+        $unique = [];
+        $seen = [];
+        $hasNull = false;
 
-        return match ($args->count()) {
-            0 => Type::mixed(),
-            1 => $args->first(),
-            default => new UnionType($args->all()),
+        foreach ($types as $type) {
+            $key = $type->toString();
+
+            if (isset($seen[$key])) {
+                continue;
+            }
+
+            $seen[$key] = true;
+            $unique[] = $type;
+            $hasNull = $hasNull || $type instanceof NullType;
+        }
+
+        // Null is carried by marking the other members nullable.
+        if ($hasNull) {
+            $nullable = [];
+
+            foreach ($unique as $type) {
+                if (! $type instanceof NullType) {
+                    $nullable[] = $type->nullable();
+                }
+            }
+
+            $unique = $nullable;
+        }
+
+        $remaining = [];
+
+        foreach ($unique as $type) {
+            if ($type instanceof MixedType) {
+                continue;
+            }
+
+            // Remove types that have a more specific counterpart.
+            foreach ($unique as $other) {
+                if ($type !== $other && $other->isMoreSpecificThan($type)) {
+                    continue 2;
+                }
+            }
+
+            $remaining[] = $type;
+        }
+
+        return match (count($remaining)) {
+            0 => self::mixed(),
+            1 => $remaining[0],
+            default => new UnionType($remaining),
         };
     }
 

--- a/src/Visitors/TypeResolver.php
+++ b/src/Visitors/TypeResolver.php
@@ -32,7 +32,7 @@ class TypeResolver extends NodeVisitorAbstract
     public function enterNode(Node $node)
     {
         Debug::increaseDepth();
-        Debug::log('❗ Entering Node: '.$node->getType().' '.$node->getStartLine(), level: 3);
+        Debug::log(static fn () => '❗ Entering Node: '.$node->getType().' '.$node->getStartLine(), level: 3);
 
         [$_, $scope] = $this->resolver->fromWithScope($node, $this->scope);
 

--- a/src/Visitors/TypeResolver.php
+++ b/src/Visitors/TypeResolver.php
@@ -32,7 +32,9 @@ class TypeResolver extends NodeVisitorAbstract
     public function enterNode(Node $node)
     {
         Debug::increaseDepth();
-        Debug::log(static fn () => '❗ Entering Node: '.$node->getType().' '.$node->getStartLine(), level: 3);
+        if (Debug::$logLevel >= Debug::TRACE) {
+            Debug::log('❗ Entering Node: '.$node->getType().' '.$node->getStartLine());
+        }
 
         [$_, $scope] = $this->resolver->fromWithScope($node, $this->scope);
 

--- a/tests/Unit/Analyzer/AnalyzedCacheTest.php
+++ b/tests/Unit/Analyzer/AnalyzedCacheTest.php
@@ -18,6 +18,9 @@ afterEach(function () {
 
 function resetCacheDirectory(): void
 {
+    // Nothing else resets this, so a frozen test would leak into every test after it.
+    AnalyzedCache::freezeFileTimes(false);
+
     $reflection = new ReflectionClass(AnalyzedCache::class);
 
     $dirProp = $reflection->getProperty('cacheDirectory');
@@ -145,6 +148,58 @@ describe('memory caching', function () {
 
         unlink($fixture1);
         unlink($fixture2);
+    });
+});
+
+describe('frozen file times', function () {
+    it('ignores modifications made while file times are frozen', function () {
+        AnalyzedCache::freezeFileTimes();
+
+        $fixture = createTestClassFixture('TestClass', 'public function test() {}');
+
+        $scope = new Scope;
+        $scope->setPath($fixture);
+        AnalyzedCache::add($fixture, $scope);
+
+        touch($fixture, time() + 10);
+
+        expect(AnalyzedCache::get($fixture))->not->toBeNull();
+
+        unlink($fixture);
+    });
+
+    it('sees modifications again once file times are unfrozen', function () {
+        AnalyzedCache::freezeFileTimes();
+
+        $fixture = createTestClassFixture('TestClass', 'public function test() {}');
+
+        $scope = new Scope;
+        $scope->setPath($fixture);
+        AnalyzedCache::add($fixture, $scope);
+
+        touch($fixture, time() + 10);
+
+        expect(AnalyzedCache::get($fixture))->not->toBeNull();
+
+        AnalyzedCache::freezeFileTimes(false);
+
+        expect(AnalyzedCache::get($fixture))->toBeNull();
+
+        unlink($fixture);
+    });
+
+    it('still invalidates on modification when not frozen', function () {
+        $fixture = createTestClassFixture('TestClass', 'public function test() {}');
+
+        $scope = new Scope;
+        $scope->setPath($fixture);
+        AnalyzedCache::add($fixture, $scope);
+
+        touch($fixture, time() + 10);
+
+        expect(AnalyzedCache::get($fixture))->toBeNull();
+
+        unlink($fixture);
     });
 });
 

--- a/tests/Unit/Analyzer/AnalyzedCacheTest.php
+++ b/tests/Unit/Analyzer/AnalyzedCacheTest.php
@@ -451,9 +451,19 @@ describe('dependency tracking', function () {
         $reflection = new ReflectionClass(AnalyzedCache::class);
         $depsProp = $reflection->getProperty('dependencies');
 
-        $deps = $depsProp->getValue();
+        $deps = array_keys($depsProp->getValue());
         expect($deps)->toContain('/path/to/dep1.php');
         expect($deps)->toContain('/path/to/dep2.php');
+    });
+
+    it('does not record a dependency twice', function () {
+        AnalyzedCache::addDependency('/path/to/dep1.php');
+        AnalyzedCache::addDependency('/path/to/dep1.php');
+
+        $reflection = new ReflectionClass(AnalyzedCache::class);
+        $depsProp = $reflection->getProperty('dependencies');
+
+        expect(array_keys($depsProp->getValue()))->toBe(['/path/to/dep1.php']);
     });
 
     it('stores dependencies when persisting to disk', function () {


### PR DESCRIPTION
These are all super high-level performance improvements that I implemented and ran against the Cloud codebase (considerably large codebase, lots of models, controllers, enums, etc).

Benchmarking harness written by Codex (kept around for future use).

Majority of these changes are pretty high-level and don't interfere too much with Surveyor's internals. Really just a case of reusing thing and reducing unnecessary work (debug logs main culprit).

On my machine, cold runs went from ~76 seconds down to ~20 seconds, warm runs also dropped by a couple of seconds. Much of the real time is spent parsing and traversing which is inherently heavy and time consuming, not much we can do about that.