### PR TITLE
Resolve Eloquent attributes built with Attribute::get() or new Attribute()

### DIFF
--- a/src/NodeResolvers/Expr/New_.php
+++ b/src/NodeResolvers/Expr/New_.php
@@ -2,9 +2,12 @@
 
 namespace Laravel\Surveyor\NodeResolvers\Expr;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Laravel\Surveyor\Analyzer\ResourceAnalyzer;
 use Laravel\Surveyor\NodeResolvers\AbstractResolver;
+use Laravel\Surveyor\NodeResolvers\Shared\ResolvesClosureReturnTypes;
+use Laravel\Surveyor\NodeResolvers\Shared\ResolvesEloquentAttributes;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Type;
 use PhpParser\Node;
@@ -12,6 +15,8 @@ use Throwable;
 
 class New_ extends AbstractResolver
 {
+    use ResolvesClosureReturnTypes, ResolvesEloquentAttributes;
+
     public function resolve(Node\Expr\New_ $node)
     {
         $type = $this->from($node->class);
@@ -22,6 +27,10 @@ class New_ extends AbstractResolver
         }
 
         $classType = new ClassType($this->scope->getUse($type->value));
+
+        if ($classType->resolved() === Attribute::class) {
+            return $this->attributeTypeFrom($node->args);
+        }
 
         $classType->setConstructorArguments(array_map(
             fn ($arg) => $this->from($arg->value),

--- a/src/NodeResolvers/Expr/StaticCall.php
+++ b/src/NodeResolvers/Expr/StaticCall.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Surveyor\NodeResolvers\Expr;
 
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Surveyor\Analysis\Condition;
@@ -10,6 +9,7 @@ use Laravel\Surveyor\Analyzer\ResourceAnalyzer;
 use Laravel\Surveyor\NodeResolvers\AbstractResolver;
 use Laravel\Surveyor\NodeResolvers\Shared\AddsValidationRules;
 use Laravel\Surveyor\NodeResolvers\Shared\ResolvesClosureReturnTypes;
+use Laravel\Surveyor\NodeResolvers\Shared\ResolvesEloquentAttributes;
 use Laravel\Surveyor\Support\Util;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\MultiType;
@@ -23,7 +23,7 @@ use Throwable;
 
 class StaticCall extends AbstractResolver
 {
-    use AddsValidationRules, ResolvesClosureReturnTypes;
+    use AddsValidationRules, ResolvesClosureReturnTypes, ResolvesEloquentAttributes;
 
     public function resolve(Node\Expr\StaticCall $node)
     {
@@ -65,20 +65,8 @@ class StaticCall extends AbstractResolver
             $class = $class->type;
         }
 
-        if (
-            $method === 'make'
-            && $class instanceof ClassType
-            && $class->resolved() === Attribute::class
-        ) {
-            $attributeType = new ClassType(Attribute::class);
-
-            if ($getArg = $this->findGetArgument($node->args)) {
-                if ($getType = $this->resolveClosureReturnType($getArg->value)) {
-                    $attributeType->setGenericTypes([$getType]);
-                }
-            }
-
-            return $attributeType;
+        if (is_string($method) && $this->isAttributeFactory($class, $method)) {
+            return $this->attributeTypeFrom($node->args);
         }
 
         $entityReturnTypes = $this->handleEntities($class, $method, $node);
@@ -214,22 +202,6 @@ class StaticCall extends AbstractResolver
                 $args[1] ?? Type::arrayShape(Type::string(), Type::mixed()),
             ),
         ];
-    }
-
-    protected function findGetArgument(array $args): ?Node\Arg
-    {
-        foreach ($args as $arg) {
-            if ($arg->name?->name === 'get') {
-                return $arg;
-            }
-        }
-
-        // Fall back to first positional argument
-        if (isset($args[0]) && $args[0]->name === null) {
-            return $args[0];
-        }
-
-        return null;
     }
 
     public function resolveForCondition(Node\Expr\StaticCall $node)

--- a/src/NodeResolvers/Shared/ResolvesEloquentAttributes.php
+++ b/src/NodeResolvers/Shared/ResolvesEloquentAttributes.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Laravel\Surveyor\NodeResolvers\Shared;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Laravel\Surveyor\Types\ClassType;
+use Laravel\Surveyor\Types\MixedType;
+use PhpParser\Node;
+
+/**
+ * Builds the type for an Eloquent attribute accessor, capturing the getter's
+ * return type as a generic so the model analyzer can read it back.
+ *
+ * Requires ResolvesClosureReturnTypes on the consuming class.
+ */
+trait ResolvesEloquentAttributes
+{
+    /**
+     * The ways an Attribute can be built where the getter is the first
+     * positional argument. Attribute::set() is left out on purpose, since its
+     * only argument is the setter.
+     *
+     * @var list<string>
+     */
+    protected array $attributeFactoryMethods = ['make', 'get'];
+
+    protected function isAttributeFactory(mixed $class, string $method): bool
+    {
+        return $class instanceof ClassType
+            && $class->resolved() === Attribute::class
+            && in_array($method, $this->attributeFactoryMethods, true);
+    }
+
+    /**
+     * @param  array<int, Node\Arg>  $args
+     */
+    protected function attributeTypeFrom(array $args): ClassType
+    {
+        $attributeType = new ClassType(Attribute::class);
+
+        if ($getArg = $this->findGetArgument($args)) {
+            $getType = $this->resolveClosureReturnType($getArg->value);
+
+            // A getter we could not read tells us nothing. Leaving the generic
+            // off lets the model analyzer fall back to the PHPDoc, which is
+            // usually more specific than mixed.
+            if ($getType !== null && ! $getType instanceof MixedType) {
+                $attributeType->setGenericTypes([$getType]);
+            }
+        }
+
+        return $attributeType;
+    }
+
+    /**
+     * @param  array<int, Node\Arg>  $args
+     */
+    protected function findGetArgument(array $args): ?Node\Arg
+    {
+        foreach ($args as $arg) {
+            if ($arg->name?->name === 'get') {
+                return $arg;
+            }
+        }
+
+        // A named argument anywhere means the first positional slot is not the
+        // getter, so only fall back when nothing is named.
+        foreach ($args as $arg) {
+            if ($arg->name !== null) {
+                return null;
+            }
+        }
+
+        return $args[0] ?? null;
+    }
+}

--- a/tests/Unit/Analyzer/ModelAnalyzerTest.php
+++ b/tests/Unit/Analyzer/ModelAnalyzerTest.php
@@ -234,6 +234,48 @@ describe('ModelAnalyzer computed attributes', function () {
         expect($property->type->keys())->toContain('currency_amount');
     });
 
+    it('extracts the getter type from Attribute::get()', function () {
+        $result = app(Analyzer::class)->analyzeClass(User::class)->result();
+
+        expect($result->hasProperty('attribute_via_static_get'))->toBeTrue();
+        expect($result->getProperty('attribute_via_static_get')->type->id())->toBe('string');
+    });
+
+    it('extracts the getter type from a new Attribute() constructor call', function () {
+        $result = app(Analyzer::class)->analyzeClass(User::class)->result();
+
+        expect($result->hasProperty('attribute_via_constructor'))->toBeTrue();
+        expect($result->getProperty('attribute_via_constructor')->type->id())->toBe('string');
+    });
+
+    it('resolves an Arrayable DTO through Attribute::get()', function () {
+        $result = app(Analyzer::class)->analyzeClass(User::class)->result();
+
+        $property = $result->getProperty('money_via_static_get');
+
+        expect($property->type)->toBeInstanceOf(ArrayType::class);
+        expect($property->type->keys())->toContain('amount', 'currency', 'currency_amount');
+    });
+
+    it('resolves an Arrayable DTO through a new Attribute() constructor call', function () {
+        $result = app(Analyzer::class)->analyzeClass(User::class)->result();
+
+        $property = $result->getProperty('money_via_constructor');
+
+        expect($property->type)->toBeInstanceOf(ArrayType::class);
+        expect($property->type->keys())->toContain('amount', 'currency', 'currency_amount');
+    });
+
+    it('does not treat the argument to Attribute::set() as a getter', function () {
+        $result = app(Analyzer::class)->analyzeClass(User::class)->result();
+
+        // The setter says string, but nothing describes what reading it gives
+        // back, so the getter type must not be taken from it.
+        if ($result->hasProperty('attribute_with_setter_only')) {
+            expect($result->getProperty('attribute_with_setter_only')->type->id())->not->toBe('string');
+        }
+    });
+
     it('extracts type from regular closure return type hint when no PHPDoc', function () {
         $analyzer = app(Analyzer::class);
         $result = $analyzer->analyzeClass(User::class)->result();

--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -142,4 +142,47 @@ class User extends Authenticatable
             ),
         );
     }
+
+    protected function attributeViaStaticGet(): Attribute
+    {
+        return Attribute::get(
+            fn (mixed $value): string => $value ?? 'fallback',
+        );
+    }
+
+    protected function attributeViaConstructor(): Attribute
+    {
+        return new Attribute(
+            get: function (): string {
+                return 'constructed';
+            },
+        );
+    }
+
+    protected function moneyViaStaticGet(): Attribute
+    {
+        return Attribute::get(
+            fn (): MoneyDTO => new MoneyDTO(
+                amount: (int) ($this->attributes['amount'] ?? 0),
+                currency: $this->attributes['currency'] ?? 'USD',
+            ),
+        );
+    }
+
+    protected function moneyViaConstructor(): Attribute
+    {
+        return new Attribute(
+            get: fn (): MoneyDTO => new MoneyDTO(
+                amount: (int) ($this->attributes['amount'] ?? 0),
+                currency: $this->attributes['currency'] ?? 'USD',
+            ),
+        );
+    }
+
+    protected function attributeWithSetterOnly(): Attribute
+    {
+        return Attribute::set(
+            fn (string $value): string => strtolower($value),
+        );
+    }
 }


### PR DESCRIPTION
Only `Attribute::make()` was recognised when reading an accessor's getter, so the other two ways of building one fell through and leaked the wrapper type into the output as `Attribute | Attribute`.

Both spellings now go through a shared trait, so `Attribute::get(fn (): string => ...)` and `new Attribute(get: ...)` resolve the same way `make()` always has. `Attribute::set()` is left out on purpose, since its only argument is the setter and the positional fallback would otherwise mistake it for a getter.

One thing worth a look in review: when the getter body cannot be read, the generic is left off rather than set to mixed, so the PHPDoc still wins. Without that, an accessor documented as `@return Attribute<string, never>` with an unreadable body went from `string` to `unknown`.
