### PR TITLE
Type singular model relations as nullable

### DIFF
--- a/src/Analyzer/ModelAnalyzer.php
+++ b/src/Analyzer/ModelAnalyzer.php
@@ -64,7 +64,9 @@ class ModelAnalyzer
                 $result->addProperty(new PropertyResult($relation['name'], $type, modelRelation: true));
                 $scope->state()->properties()->addManually($relation['name'], $type, 0, 0, 0, 0);
             } else {
-                $type = new ClassType($relation['related']);
+                // A singular relation has nothing to return when the related
+                // record is missing, whatever the foreign key says.
+                $type = (new ClassType($relation['related']))->nullable();
                 $result->addProperty(new PropertyResult($relation['name'], $type, modelRelation: true));
                 $scope->state()->properties()->addManually($relation['name'], $type, 0, 0, 0, 0);
             }

--- a/tests/Unit/Analyzer/ModelAnalyzerTest.php
+++ b/tests/Unit/Analyzer/ModelAnalyzerTest.php
@@ -68,6 +68,23 @@ describe('ModelAnalyzer relations', function () {
         expect($postsProperty->modelRelation)->toBeTrue();
     });
 
+    it('types a singular relation as nullable', function () {
+        $result = app(Analyzer::class)->analyzeClass(Post::class)->result();
+
+        expect($result->hasProperty('user'))->toBeTrue();
+
+        // The related record may not exist, so reading the relation can give
+        // back null no matter what the foreign key allows.
+        expect($result->getProperty('user')->type->isNullable())->toBeTrue();
+    });
+
+    it('does not type a collection relation as nullable', function () {
+        $result = app(Analyzer::class)->analyzeClass(User::class)->result();
+
+        expect($result->hasProperty('posts'))->toBeTrue();
+        expect($result->getProperty('posts')->type->isNullable())->toBeFalse();
+    });
+
     it('correctly identifies collection relations vs singular relations', function () {
         $analyzer = app(Analyzer::class);
 


### PR DESCRIPTION
Relations that return a single record were typed as always present. Reading one gives back null when the related record is missing, whatever the foreign key allows, so `HasOne`, `BelongsTo`, `MorphOne`, `MorphTo` and `HasOneThrough` are now nullable. Collection relations are unchanged.