### PR TITLE
Invalidate the analysis cache per file

### DIFF
--- a/benchmarks/cache/bench.sh
+++ b/benchmarks/cache/bench.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Times the three scenarios that matter for whichever Surveyor is checked out,
+# repeated so the numbers can be trusted:
+#
+#   cold        empty cache
+#   warm        nothing changed since the cold build
+#   warm+edit   one file touched since the cold build
+#
+# Prints one TSV row per repeat, plus the cache size and how many entries the
+# edit forced back through the analyzer.
+#
+# Usage: bench.sh <label> [repeats]
+
+set -u
+
+S="$(cd "$(dirname "$0")" && pwd)"
+APP=/Users/joetannenbaum/Herd/cloud
+LABEL=$1
+RUNS=${2:-3}
+TARGET=app/Models/Instance.php
+
+cd "$APP" || exit 1
+
+if ! git diff --quiet; then
+  echo "ABORT: tracked files in cloud are modified"
+  exit 1
+fi
+
+trap 'cd "$APP" && git checkout -- . 2>/dev/null' EXIT
+
+time_run() {
+  local cache=$1 out=$2 start end
+  rm -rf "$out"; mkdir -p "$out"
+  start=$(php -r 'echo microtime(true);')
+  WAYFINDER_CACHE_DIRECTORY=$cache php artisan wayfinder:generate --path="$out" > /dev/null 2>&1
+  end=$(php -r 'echo microtime(true);')
+  php -r "printf('%.2f', $end - $start);"
+}
+
+for i in $(seq 1 "$RUNS"); do
+  CACHE=$S/bn-$LABEL-cache
+  rm -rf "$CACHE"; mkdir -p "$CACHE"
+
+  cold=$(time_run "$CACHE" "$S/bn-out")
+  entries=$(find "$CACHE" -name '*.cache' | wc -l | tr -d ' ')
+  size=$(du -sm "$CACHE" | cut -f1 | tr -d ' ')
+
+  warm=$(time_run "$CACHE" "$S/bn-out")
+
+  before=$(mktemp)
+  find "$CACHE" -name '*.cache' -exec stat -f '%N %m' {} \; | sort > "$before"
+
+  sleep 1
+  python3 - "$APP/$TARGET" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+i = s.rstrip().rfind('\n}')
+probe = "\n    public function benchProbeRelation(): HasOne\n    {\n        return $this->hasOne(Daemon::class);\n    }\n"
+open(p, 'w').write(s[:i] + probe + s[i:])
+PY
+
+  edit=$(time_run "$CACHE" "$S/bn-out")
+
+  after=$(mktemp)
+  find "$CACHE" -name '*.cache' -exec stat -f '%N %m' {} \; | sort > "$after"
+  rewritten=$(comm -13 "$before" "$after" | wc -l | tr -d ' ')
+
+  git checkout -- "$TARGET"
+  rm -f "$before" "$after"
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$LABEL" "$i" "$cold" "$warm" "$edit" "$entries" "$size" "$rewritten"
+done

--- a/benchmarks/cache/divergence.sh
+++ b/benchmarks/cache/divergence.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Does a warm-cache run after one edit produce the same output as a cold run?
+#
+# Usage: divergence.sh <label> [target-relative-path]
+#
+# Builds a cold cache, edits one file, then generates twice: once against the
+# warm cache and once from scratch. Leaves both caches and both outputs behind
+# for inspection.
+
+set -u
+
+S="$(cd "$(dirname "$0")" && pwd)"
+APP=/Users/joetannenbaum/Herd/cloud
+LABEL=$1
+TARGET=${2:-app/Models/Instance.php}
+
+CACHE_WARM=$S/dv-$LABEL-cache-warm
+CACHE_COLD=$S/dv-$LABEL-cache-cold
+OUT_BASE=$S/dv-$LABEL-base
+OUT_WARM=$S/dv-$LABEL-warm
+OUT_COLD=$S/dv-$LABEL-cold
+
+cd "$APP" || exit 1
+
+if ! git diff --quiet; then
+  echo "ABORT: tracked files in cloud are modified"
+  exit 1
+fi
+
+trap 'cd "$APP" && git checkout -- . 2>/dev/null' EXIT
+
+run() {
+  local cache=$1 out=$2
+  rm -rf "$out"; mkdir -p "$out"
+  WAYFINDER_CACHE_DIRECTORY=$cache php artisan wayfinder:generate --path="$out" > /dev/null 2>&1
+}
+
+rm -rf "$CACHE_WARM" "$CACHE_COLD"; mkdir -p "$CACHE_WARM" "$CACHE_COLD"
+
+echo "building cold cache..."
+run "$CACHE_WARM" "$OUT_BASE"
+echo "  $(ls "$CACHE_WARM" | grep -c '\.cache') entries"
+
+sleep 1
+
+python3 - "$APP/$TARGET" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+i = s.rstrip().rfind('\n}')
+probe = "\n    protected function sweepProbeAccessor(): Attribute\n    {\n        return Attribute::get(fn (): string => 'probe');\n    }\n"
+open(p, 'w').write(s[:i] + probe + s[i:])
+PY
+
+echo "warm run (cache reused)..."
+run "$CACHE_WARM" "$OUT_WARM"
+
+echo "cold run (empty cache)..."
+run "$CACHE_COLD" "$OUT_COLD"
+
+cd "$APP" && git checkout -- "$TARGET"
+
+mask() {
+  rm -rf "$2"; cp -R "$1" "$2"
+  find "$2" -type f -exec sed -i '' -E 's/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z?/<TS>/g' {} \;
+}
+
+mask "$OUT_WARM" "$S/dv-$LABEL-warm-masked"
+mask "$OUT_COLD" "$S/dv-$LABEL-cold-masked"
+
+echo
+echo "=== output diff (cold < , warm > ) ==="
+diff -r "$S/dv-$LABEL-cold-masked" "$S/dv-$LABEL-warm-masked" > "$S/dv-$LABEL.diff" 2>&1
+raw=$(grep -c '^[<>]' "$S/dv-$LABEL.diff")
+sorted=$(diff <(sort "$S/dv-$LABEL-cold-masked/types.d.ts") <(sort "$S/dv-$LABEL-warm-masked/types.d.ts") | grep -c '^[<>]')
+echo "raw lines: $raw   sorted (order-insensitive) lines: $sorted"
+echo
+diff <(sort "$S/dv-$LABEL-cold-masked/types.d.ts") <(sort "$S/dv-$LABEL-warm-masked/types.d.ts") | grep '^[<>]' | cut -c1-150
+echo
+echo "other differing files:"
+diff -rq "$S/dv-$LABEL-cold-masked" "$S/dv-$LABEL-warm-masked" | grep -v 'types.d.ts'
+echo
+echo "full diff: $S/dv-$LABEL.diff"
+echo "caches: $CACHE_WARM (warm) / $CACHE_COLD (cold)"

--- a/benchmarks/cache/fielddiff.py
+++ b/benchmarks/cache/fielddiff.py
@@ -1,0 +1,91 @@
+"""Pairs changed type declarations across two generated types.d.ts files and
+reports which fields differ, so each change can be judged on its own.
+
+Usage: python3 fielddiff.py <a.ts> <b.ts>
+"""
+
+import re
+import sys
+
+a_path, b_path = sys.argv[1], sys.argv[2]
+
+
+def decls(path):
+    """Map each `export type X = ...` line to its full text, keyed by name plus
+    a slice of context so same-named types in different namespaces stay apart."""
+    out = {}
+    ns = []
+    for raw in open(path):
+        line = raw.rstrip("\n")
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip())
+        while ns and ns[-1][0] >= indent:
+            ns.pop()
+        m = re.match(r"export namespace (\w+) \{", stripped)
+        if m:
+            ns.append((indent, m.group(1)))
+            continue
+        m = re.match(r"export type (\w+) = (.*)$", stripped)
+        if m:
+            key = ".".join(n for _, n in ns) + "." + m.group(1)
+            out[key] = m.group(2)
+    return out
+
+
+A, B = decls(a_path), decls(b_path)
+
+only_a = sorted(set(A) - set(B))
+only_b = sorted(set(B) - set(A))
+changed = sorted(k for k in set(A) & set(B) if A[k] != B[k])
+
+print(f"declarations: {len(A)} in A, {len(B)} in B")
+print(f"only in A: {len(only_a)}   only in B: {len(only_b)}   changed: {len(changed)}\n")
+
+for k in only_a:
+    print(f"REMOVED  {k}\n         {A[k][:150]}\n")
+for k in only_b:
+    print(f"ADDED    {k}\n         {B[k][:150]}\n")
+
+
+def fields(text):
+    """Split a flat object type into top-level `key: value` pairs."""
+    out, depth, buf = {}, 0, ""
+    for ch in text:
+        if ch in "{[(":
+            depth += 1
+        elif ch in "}])":
+            depth -= 1
+        if ch == "," and depth <= 1:
+            out.update(kv(buf))
+            buf = ""
+        else:
+            buf += ch
+    out.update(kv(buf))
+    return out
+
+
+def kv(chunk):
+    chunk = chunk.strip().lstrip("{").rstrip("}").strip()
+    if ":" not in chunk:
+        return {}
+    k, v = chunk.split(":", 1)
+    return {k.strip(): v.strip()}
+
+
+for k in changed:
+    fa, fb = fields(A[k]), fields(B[k])
+    diffs = [
+        (f, fa.get(f, "<absent>"), fb.get(f, "<absent>"))
+        for f in sorted(set(fa) | set(fb))
+        if fa.get(f) != fb.get(f)
+    ]
+    print(f"CHANGED  {k}")
+    if not diffs:
+        print(f"         (differs below top level)")
+        print(f"         A: {A[k][:200]}")
+        print(f"         B: {B[k][:200]}")
+    for f, va, vb in diffs:
+        print(f"         {f}:")
+        print(f"           main: {va[:170]}")
+        print(f"           fix : {vb[:170]}")
+    print()

--- a/benchmarks/cache/mutate.py
+++ b/benchmarks/cache/mutate.py
@@ -1,0 +1,94 @@
+"""Applies one named source mutation to the Cloud checkout.
+
+Usage: mutate.py <shape> <phase>
+
+Phases: `pre` runs before the base cache is built, `apply` is the change under
+test. Most shapes only use `apply`; the removal and rename shapes need the file
+to exist in the base build first.
+"""
+
+import os
+import re
+import sys
+
+APP = "/Users/joetannenbaum/Herd/cloud"
+INSTANCE = f"{APP}/app/Models/Instance.php"
+ENUM = f"{APP}/app/Enums/InstanceType.php"
+PROBE = f"{APP}/app/Enums/SweepProbeEnum.php"
+PROBE_RENAMED = f"{APP}/app/Enums/SweepProbeRenamed.php"
+
+PROBE_BODY = """<?php
+
+namespace App\\Enums;
+
+enum {name}: string
+{{
+    case ProbeAlpha = 'probe_alpha';
+    case ProbeBeta = 'probe_beta';
+}}
+"""
+
+shape, phase = sys.argv[1], sys.argv[2]
+
+
+def read(p):
+    return open(p).read()
+
+
+def write(p, s):
+    open(p, "w").write(s)
+
+
+def append_method():
+    s = read(INSTANCE)
+    i = s.rstrip().rfind("\n}")
+    probe = (
+        "\n    public function sweepProbeRelation(): HasOne\n"
+        "    {\n        return $this->hasOne(Daemon::class);\n    }\n"
+    )
+    write(INSTANCE, s[:i] + probe + s[i:])
+
+
+def remove_method(name):
+    s = read(INSTANCE)
+    m = re.search(rf"\n    public function {name}\(", s)
+    if not m:
+        sys.exit(f"method {name} not found")
+    # Method bodies in this file are brace-balanced and indented four spaces,
+    # so the first `\n    }` after the signature closes it.
+    end = s.index("\n    }", m.start()) + len("\n    }")
+    write(INSTANCE, s[: m.start()] + s[end:])
+
+
+def edit_enum_case():
+    s = read(ENUM)
+    if "MANAGED_QUEUE = 'managed_queue'" not in s:
+        sys.exit("enum case not found")
+    write(ENUM, s.replace("MANAGED_QUEUE = 'managed_queue'", "MANAGED_QUEUE = 'managed_queue_probe'"))
+
+
+def add_probe(path, name):
+    write(path, PROBE_BODY.format(name=name))
+
+
+def remove(path):
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+actions = {
+    ("append-method", "apply"): append_method,
+    ("remove-method", "apply"): lambda: remove_method("activeScheduledAutoscaleOverride"),
+    ("edit-enum-case", "apply"): edit_enum_case,
+    ("add-file", "apply"): lambda: add_probe(PROBE, "SweepProbeEnum"),
+    ("remove-file", "pre"): lambda: add_probe(PROBE, "SweepProbeEnum"),
+    ("remove-file", "apply"): lambda: remove(PROBE),
+    ("rename-file", "pre"): lambda: add_probe(PROBE, "SweepProbeEnum"),
+    ("rename-file", "apply"): lambda: (remove(PROBE), add_probe(PROBE_RENAMED, "SweepProbeRenamed")),
+    ("cleanup", "apply"): lambda: (remove(PROBE), remove(PROBE_RENAMED)),
+}
+
+action = actions.get((shape, phase))
+
+if action:
+    action()

--- a/benchmarks/cache/patchdiff.sh
+++ b/benchmarks/cache/patchdiff.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Builds an app's generated output twice — once with the Surveyor working-tree
+# change applied, once without — and diffs the two.
+#
+# Works off the uncommitted change rather than branches, so nothing is committed
+# and the change is restored either way.
+#
+# Usage: patchdiff.sh <label> <app-path> [file-to-toggle]
+
+set -u
+
+S="$(cd "$(dirname "$0")" && pwd)"
+SUR=/Users/joetannenbaum/Dev/surveyor
+LABEL=$1
+APP=$2
+FILE=${3:-src/NodeResolvers/Expr/Ternary.php}
+PATCH=$S/pd-$LABEL.patch
+
+if [ -z "$(git -C "$SUR" diff -- "$FILE")" ]; then
+  echo "ABORT: no working-tree change in $FILE to toggle"
+  exit 1
+fi
+
+git -C "$SUR" diff -- "$FILE" > "$PATCH"
+
+restore() {
+  git -C "$SUR" checkout -- "$FILE" 2>/dev/null
+  git -C "$SUR" apply "$PATCH" 2>/dev/null
+}
+trap restore EXIT
+
+build() {
+  local out=$1 cache=$2
+  rm -rf "$out" "$cache"; mkdir -p "$out" "$cache"
+  (cd "$APP" && WAYFINDER_CACHE_DIRECTORY=$cache php artisan wayfinder:generate --path="$out" > /dev/null 2>&1)
+  rm -rf "$out-masked"; cp -R "$out" "$out-masked"
+  find "$out-masked" -type f -exec sed -i '' -E 's/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z?/<TS>/g' {} \;
+}
+
+echo "building WITH the fix ..."
+build "$S/pd-$LABEL-fix" "$S/pd-$LABEL-cache-a"
+
+echo "reverting and building WITHOUT the fix ..."
+git -C "$SUR" checkout -- "$FILE"
+build "$S/pd-$LABEL-main" "$S/pd-$LABEL-cache-b"
+
+git -C "$SUR" apply "$PATCH"
+
+echo
+echo "=== $LABEL cold output: without fix (<) vs with fix (>) ==="
+if [ ! -s "$S/pd-$LABEL-main-masked/types.d.ts" ] || [ ! -s "$S/pd-$LABEL-fix-masked/types.d.ts" ]; then
+  echo "WARNING: one or both builds produced no types.d.ts"
+  ls -la "$S/pd-$LABEL-main-masked" "$S/pd-$LABEL-fix-masked" 2>&1 | head -20
+  exit 1
+fi
+
+diff -r "$S/pd-$LABEL-main-masked" "$S/pd-$LABEL-fix-masked" > "$S/pd-$LABEL.diff" 2>&1
+echo "raw lines:    $(grep -c '^[<>]' "$S/pd-$LABEL.diff")"
+echo "declarations: $(python3 "$S/fielddiff.py" "$S/pd-$LABEL-main-masked/types.d.ts" "$S/pd-$LABEL-fix-masked/types.d.ts" | head -2 | tail -1)"
+echo
+python3 "$S/fielddiff.py" "$S/pd-$LABEL-main-masked/types.d.ts" "$S/pd-$LABEL-fix-masked/types.d.ts"

--- a/benchmarks/cache/shapesweep.sh
+++ b/benchmarks/cache/shapesweep.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Runs each kind of source change through a warm cache and a cold one, and
+# reports whether the two agree.
+#
+# Covers the shapes the earlier sweeps never touched: removing a method,
+# editing in place, adding a file, deleting a file, renaming a file.
+#
+# Usage: shapesweep.sh <label>
+
+set -u
+
+S="$(cd "$(dirname "$0")" && pwd)"
+APP=/Users/joetannenbaum/Herd/cloud
+LABEL=$1
+KEEP=$S/sh-$LABEL
+CACHE_W=$S/sh-cache-w
+CACHE_C=$S/sh-cache-c
+
+SHAPES=(append-method remove-method edit-enum-case add-file remove-file rename-file)
+
+cd "$APP" || exit 1
+
+if ! git diff --quiet; then
+  echo "ABORT: tracked files in cloud are modified"
+  exit 1
+fi
+
+cleanup() {
+  cd "$APP" && git checkout -- . 2>/dev/null
+  python3 "$S/mutate.py" cleanup apply
+}
+trap cleanup EXIT
+
+rm -rf "$KEEP"; mkdir -p "$KEEP"
+
+run() {
+  local cache=$1 out=$2
+  rm -rf "$out"; mkdir -p "$out"
+  WAYFINDER_CACHE_DIRECTORY=$cache php artisan wayfinder:generate --path="$out" > /dev/null 2>&1
+}
+
+mask() {
+  sed -E 's/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z?/<TS>/g' "$1"
+}
+
+printf '%-16s %14s %8s %s\n' shape warm-vs-cold raw effect
+
+for shape in "${SHAPES[@]}"; do
+  cd "$APP" && git checkout -- . 2>/dev/null
+  python3 "$S/mutate.py" cleanup apply
+
+  python3 "$S/mutate.py" "$shape" pre
+
+  rm -rf "$CACHE_W" "$CACHE_C"; mkdir -p "$CACHE_W" "$CACHE_C"
+  run "$CACHE_W" "$S/sh-out-base"
+  mask "$S/sh-out-base/types.d.ts" > "$KEEP/$shape.base"
+
+  sleep 1
+
+  python3 "$S/mutate.py" "$shape" apply
+
+  run "$CACHE_W" "$S/sh-out-w"
+  run "$CACHE_C" "$S/sh-out-c"
+
+  mask "$S/sh-out-w/types.d.ts" > "$KEEP/$shape.warm"
+  mask "$S/sh-out-c/types.d.ts" > "$KEEP/$shape.cold"
+
+  sorted=$(diff <(sort "$KEEP/$shape.cold") <(sort "$KEEP/$shape.warm") | grep -c '^[<>]')
+  raw=$(diff "$KEEP/$shape.cold" "$KEEP/$shape.warm" | grep -c '^[<>]')
+  moved=$(diff "$KEEP/$shape.base" "$KEEP/$shape.cold" | grep -c '^[<>]')
+
+  effect="changed $moved lines"
+  [ "$moved" -eq 0 ] && effect="NO EFFECT ON OUTPUT (vacuous test)"
+
+  printf '%-16s %14s %8s %s\n' "$shape" "$sorted" "$raw" "$effect"
+
+  if [ "$sorted" -gt 0 ]; then
+    diff <(sort "$KEEP/$shape.cold") <(sort "$KEEP/$shape.warm") | grep '^[<>]' \
+      | grep -v '@see' | cut -c1-130 | head -6 | sed 's/^/      /'
+  fi
+done
+
+echo
+echo "kept: $KEEP"

--- a/benchmarks/cache/sweepcmp.sh
+++ b/benchmarks/cache/sweepcmp.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# For each target file: build a cold cache, edit the file, then generate twice
+# (warm cache vs empty cache) and report how far apart the two outputs are.
+#
+# Every target gets its own freshly built cache, so results do not carry over
+# between targets.
+#
+# Usage: sweepcmp.sh <label>
+#
+# Keeps the masked types.d.ts of both runs per target, so outputs can later be
+# compared across labels.
+
+set -u
+
+S="$(cd "$(dirname "$0")" && pwd)"
+APP=/Users/joetannenbaum/Herd/cloud
+LABEL=$1
+KEEP=$S/sw-$LABEL
+CACHE_W=$S/sw-cache-w
+CACHE_C=$S/sw-cache-c
+OUT_W=$S/sw-out-w
+OUT_C=$S/sw-out-c
+
+TARGETS=(
+  app/Models/Instance.php
+  app/Models/Environment.php
+  app/Models/Application.php
+  app/Models/Organization.php
+  app/Models/User.php
+  app/Enums/InstanceType.php
+  app/Enums/AlertType.php
+  app/Support/ClickHouse/Builder.php
+  app/Support/Metrics/ManagedQueueChartQuery.php
+  app/Actions/ReplicateEnvironment.php
+  app/Http/Resources/Dashboard/EnvironmentResource.php
+  app/Http/Resources/Dashboard/CacheResource.php
+)
+
+cd "$APP" || exit 1
+
+if ! git diff --quiet; then
+  echo "ABORT: tracked files in cloud are modified"
+  exit 1
+fi
+
+trap 'cd "$APP" && git checkout -- . 2>/dev/null' EXIT
+
+rm -rf "$KEEP"; mkdir -p "$KEEP"
+
+run() {
+  local cache=$1 out=$2
+  rm -rf "$out"; mkdir -p "$out"
+  WAYFINDER_CACHE_DIRECTORY=$cache php artisan wayfinder:generate --path="$out" > /dev/null 2>&1
+}
+
+mask() {
+  sed -E 's/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z?/<TS>/g' "$1"
+}
+
+printf '%-56s %8s %8s %s\n' target warm-vs-cold raw note
+
+for target in "${TARGETS[@]}"; do
+  slug=$(echo "$target" | tr '/' '_')
+
+  rm -rf "$CACHE_W" "$CACHE_C"; mkdir -p "$CACHE_W" "$CACHE_C"
+  run "$CACHE_W" "$S/sw-out-base"
+  mask "$S/sw-out-base/types.d.ts" > "$KEEP/$slug.base"
+
+  sleep 1
+
+  python3 - "$APP/$target" <<'PY'
+import sys, re
+p = sys.argv[1]
+s = open(p).read()
+i = s.rstrip().rfind('\n}')
+if i == -1:
+    sys.exit(9)
+
+if '/Enums/' in p and re.search(r'^\s*case\s+\w+', s, re.M):
+    m = list(re.finditer(r'^(\s*)case\s+(\w+)\s*=\s*(.+?);\s*$', s, re.M))[-1]
+    indent, val = m.group(1), m.group(3)
+    lit = "'sweep_probe'" if val.strip().startswith("'") else "999999"
+    s = s[:m.end()] + f"\n{indent}case SweepProbeCase = {lit};" + s[m.end():]
+elif 'Attribute;' in s:
+    probe = "\n    protected function sweepProbeAccessor(): Attribute\n    {\n        return Attribute::get(fn (): string => 'probe');\n    }\n"
+    s = s[:i] + probe + s[i:]
+else:
+    probe = "\n    public function sweepProbeMethod(): \\App\\Models\\User\n    {\n        return new \\App\\Models\\User;\n    }\n"
+    s = s[:i] + probe + s[i:]
+
+open(p, 'w').write(s)
+PY
+  if [ $? -ne 0 ]; then printf '%-56s %8s\n' "$target" skip; continue; fi
+
+  run "$CACHE_W" "$OUT_W"
+  run "$CACHE_C" "$OUT_C"
+
+  git checkout -- "$target"
+
+  mask "$OUT_W/types.d.ts" > "$KEEP/$slug.warm"
+  mask "$OUT_C/types.d.ts" > "$KEEP/$slug.cold"
+
+  sorted=$(diff <(sort "$KEEP/$slug.cold") <(sort "$KEEP/$slug.warm") | grep -c '^[<>]')
+  raw=$(diff "$KEEP/$slug.cold" "$KEEP/$slug.warm" | grep -c '^[<>]')
+  moved=$(diff "$KEEP/$slug.base" "$KEEP/$slug.cold" | grep -c '^[<>]')
+
+  note=""
+  [ "$moved" -eq 0 ] && note="(edit changed no output)"
+
+  printf '%-56s %8s %8s %s\n' "$target" "$sorted" "$raw" "$note"
+
+  if [ "$sorted" -gt 0 ]; then
+    diff <(sort "$KEEP/$slug.cold") <(sort "$KEEP/$slug.warm") | grep '^[<>]' \
+      | grep -v '@see\|^\s*[<>]\s*\*/\?$\|^[<>] *$' | cut -c1-140 | head -6 | sed 's/^/      /'
+  fi
+done
+
+echo
+echo "kept: $KEEP"

--- a/src/Analyzer/AnalyzedCache.php
+++ b/src/Analyzer/AnalyzedCache.php
@@ -20,7 +20,38 @@ class AnalyzedCache
 
     protected static bool $persistToDisk = false;
 
-    /** @var array<string, true> */
+    /**
+     * Dependencies collected for each analysis currently on the stack. The
+     * innermost frame belongs to the file being analyzed right now.
+     *
+     * @var list<array<string, true>>
+     */
+    protected static array $frames = [];
+
+    /** @var list<string> */
+    protected static array $framePaths = [];
+
+    /**
+     * Whether each frame skipped a file that was still being analyzed, which
+     * leaves its dependency list incomplete.
+     *
+     * @var list<bool>
+     */
+    protected static array $frameTainted = [];
+
+    /** Index of the outermost frame taking part in an unresolved cycle. */
+    protected static ?int $cycleFloor = null;
+
+    /** @var list<array{path: string, scope: Scope, mtime: int}> */
+    protected static array $deferred = [];
+
+    /**
+     * Every file each analyzed path depends on, directly or otherwise. Stored
+     * as a closure rather than direct edges so a cache entry can be validated
+     * by stat'ing a flat list, without walking the graph.
+     *
+     * @var array<string, array<string, true>>
+     */
     protected static array $dependencies = [];
 
     /** @var array<string, int|null> */
@@ -35,11 +66,125 @@ class AnalyzedCache
         static::$key = $key;
     }
 
+    /**
+     * Record that the analysis in progress depends on the given path, along
+     * with everything that path itself depends on.
+     */
     public static function addDependency(string $path): void
     {
-        // Keyed by path to avoid duplicates. The full list is written into
-        // every cache file, and it only grows.
-        static::$dependencies[$path] = true;
+        if (static::$frames === []) {
+            return;
+        }
+
+        $frame = array_key_last(static::$frames);
+
+        static::$frames[$frame][$path] = true;
+
+        // A path resolved from cache is never pushed as a frame of its own, so
+        // its dependencies have to be folded in here or they are lost.
+        if (isset(static::$dependencies[$path])) {
+            static::$frames[$frame] += static::$dependencies[$path];
+        }
+    }
+
+    public static function beginAnalysis(string $path): void
+    {
+        static::$frames[] = [];
+        static::$framePaths[] = $path;
+        static::$frameTainted[] = false;
+    }
+
+    /**
+     * Record that the analysis in progress gave up on a file that is already
+     * being analyzed further up the stack. Everything between that file and
+     * here is mutually dependent, so none of it can be cached until the
+     * outermost member finishes and the full closure is known.
+     */
+    public static function noteCycle(string $path): void
+    {
+        if (static::$frames === []) {
+            return;
+        }
+
+        static::$frameTainted[array_key_last(static::$frameTainted)] = true;
+
+        // The file should always be somewhere on the stack, since that is what
+        // makes it in progress. Fall back to the outermost frame rather than
+        // caching a dependency list that is missing whatever it reached.
+        $root = array_search($path, static::$framePaths, true);
+
+        if ($root === false) {
+            $root = 0;
+        }
+
+        static::$cycleFloor = static::$cycleFloor === null
+            ? $root
+            : min(static::$cycleFloor, $root);
+    }
+
+    /**
+     * Close the analysis of a path, keep its dependency closure, and fold that
+     * closure into the analysis that asked for it.
+     */
+    public static function endAnalysis(string $path): void
+    {
+        if (static::$frames === []) {
+            return;
+        }
+
+        $index = array_key_last(static::$frames);
+
+        $dependencies = array_pop(static::$frames);
+        $tainted = array_pop(static::$frameTainted);
+        array_pop(static::$framePaths);
+
+        unset($dependencies[$path]);
+
+        static::$dependencies[$path] = $dependencies;
+
+        if (static::$frames !== []) {
+            $frame = array_key_last(static::$frames);
+            static::$frames[$frame] += $dependencies;
+
+            if ($tainted) {
+                static::$frameTainted[$frame] = true;
+            }
+        }
+
+        if ($index === static::$cycleFloor) {
+            static::$cycleFloor = null;
+            static::flushDeferred($dependencies, $path);
+        }
+    }
+
+    /**
+     * Write out the entries held back while a cycle was open. Every member of
+     * the cycle gets the closure of its outermost file plus every other member,
+     * since a change to any of them could change all of them.
+     *
+     * @param  array<string, true>  $dependencies
+     */
+    protected static function flushDeferred(array $dependencies, string $root): void
+    {
+        $deferred = static::$deferred;
+        static::$deferred = [];
+
+        $dependencies[$root] = true;
+
+        foreach ($deferred as $entry) {
+            $dependencies[$entry['path']] = true;
+        }
+
+        foreach ($deferred as $entry) {
+            $own = $dependencies;
+            unset($own[$entry['path']]);
+
+            static::$dependencies[$entry['path']] = $own;
+
+            if (static::$persistToDisk) {
+                static::persistToDisk($entry['path'], $entry['scope'], $entry['mtime'], $own);
+            }
+        }
     }
 
     /**
@@ -117,8 +262,19 @@ class AnalyzedCache
         static::$fileTimes[$path] = $mtime;
         unset(static::$inProgress[$path]);
 
-        if (static::$persistToDisk && $mtime !== null) {
-            static::persistToDisk($path, $analyzed, $mtime);
+        if ($mtime === null) {
+            return;
+        }
+
+        // Its dependency list is still missing whatever the cycle resolves to.
+        if (static::$cycleFloor !== null && (static::$frameTainted[array_key_last(static::$frameTainted)] ?? false)) {
+            static::$deferred[] = ['path' => $path, 'scope' => $analyzed, 'mtime' => $mtime];
+
+            return;
+        }
+
+        if (static::$persistToDisk) {
+            static::persistToDisk($path, $analyzed, $mtime, static::pendingDependencies($path));
         }
     }
 
@@ -190,6 +346,8 @@ class AnalyzedCache
             return null;
         }
 
+        $dependencies = [];
+
         foreach ($data['dependencies'] as $dependency) {
             $currentMtime = static::modifiedTime($dependency['path']);
 
@@ -199,7 +357,13 @@ class AnalyzedCache
 
                 return null;
             }
+
+            $dependencies[$dependency['path']] = true;
         }
+
+        // Whoever asked for this path inherits its dependencies, so a change
+        // further down the graph still invalidates the files above it.
+        static::$dependencies[$path] = $dependencies;
 
         $serialized = $data['scope'];
         unset($data);
@@ -253,6 +417,11 @@ class AnalyzedCache
         static::$fileTimes = [];
         static::$inProgress = [];
         static::$dependencies = [];
+        static::$frames = [];
+        static::$framePaths = [];
+        static::$frameTainted = [];
+        static::$cycleFloor = null;
+        static::$deferred = [];
         static::$modifiedTimes = [];
     }
 
@@ -278,7 +447,28 @@ class AnalyzedCache
         return self::$inProgress[$path] ?? false;
     }
 
-    protected static function persistToDisk(string $path, Scope $analyzed, int $mtime): void
+    /**
+     * The dependency closure for a path that is being cached. Entries are
+     * written while their frame is still open, so the open frame is the
+     * authoritative list.
+     *
+     * @return array<string, true>
+     */
+    protected static function pendingDependencies(string $path): array
+    {
+        $dependencies = static::$frames === []
+            ? (static::$dependencies[$path] ?? [])
+            : static::$frames[array_key_last(static::$frames)];
+
+        unset($dependencies[$path]);
+
+        return $dependencies;
+    }
+
+    /**
+     * @param  array<string, true>  $dependencies
+     */
+    protected static function persistToDisk(string $path, Scope $analyzed, int $mtime, array $dependencies): void
     {
         // Ensure cache directory exists
         if (! is_dir(static::$cacheDirectory)) {
@@ -292,7 +482,7 @@ class AnalyzedCache
             'dependencies' => array_values(array_filter(array_map(fn ($dep) => [
                 'path' => $dep,
                 'mtime' => static::modifiedTime($dep),
-            ], array_keys(self::$dependencies)), fn ($dep) => $dep['mtime'] !== null)),
+            ], array_keys($dependencies)), fn ($dep) => $dep['mtime'] !== null)),
             'scope' => $analyzed,
         ];
 

--- a/src/Analyzer/Analyzer.php
+++ b/src/Analyzer/Analyzer.php
@@ -34,9 +34,7 @@ class Analyzer
             return $this;
         }
 
-        if ($this->analyzing > 0) {
-            AnalyzedCache::addDependency($path);
-        }
+        AnalyzedCache::addDependency($path);
 
         $this->analyzing++;
 
@@ -53,6 +51,8 @@ class Analyzer
         }
 
         if (AnalyzedCache::isInProgress($path)) {
+            AnalyzedCache::noteCycle($path);
+
             Debug::log(static fn () => '⏳ Waiting for analysis to complete: '.self::shortPath($path));
 
             // The in-progress scope isn't available yet, so anything still held
@@ -68,14 +68,20 @@ class Analyzer
 
         Debug::log(static fn () => '🧠 Analyzing: '.self::shortPath($path));
 
-        $analyzed = $this->parser->parse(file_get_contents($path), $path);
+        AnalyzedCache::beginAnalysis($path);
 
-        foreach ($analyzed as $result) {
-            if ($result->fullPath() === $path) {
-                $this->analyzed = $result;
+        try {
+            $analyzed = $this->parser->parse(file_get_contents($path), $path);
+
+            foreach ($analyzed as $result) {
+                if ($result->fullPath() === $path) {
+                    $this->analyzed = $result;
+                }
+
+                AnalyzedCache::add($result->fullPath(), $result);
             }
-
-            AnalyzedCache::add($result->fullPath(), $result);
+        } finally {
+            AnalyzedCache::endAnalysis($path);
         }
 
         Debug::removePath($path);

--- a/src/Analyzer/ArrayableResolver.php
+++ b/src/Analyzer/ArrayableResolver.php
@@ -50,7 +50,9 @@ class ArrayableResolver
         }
 
         try {
-            if (AnalyzedCache::isInProgress((new ReflectionClass($className))->getFileName())) {
+            if (AnalyzedCache::isInProgress($file = (new ReflectionClass($className))->getFileName())) {
+                AnalyzedCache::noteCycle($file);
+
                 return null;
             }
         } catch (Throwable $e) {

--- a/src/Analyzer/ResourceAnalyzer.php
+++ b/src/Analyzer/ResourceAnalyzer.php
@@ -117,7 +117,9 @@ class ResourceAnalyzer
             return $this->buildJsonApiResourceResponse($resourceClass, $isCollection);
         }
 
-        if (AnalyzedCache::isInProgress((new ReflectionClass($resourceClass))->getFileName())) {
+        if (AnalyzedCache::isInProgress($file = (new ReflectionClass($resourceClass))->getFileName())) {
+            AnalyzedCache::noteCycle($file);
+
             return null;
         }
 
@@ -518,7 +520,9 @@ class ResourceAnalyzer
             return null;
         }
 
-        if (AnalyzedCache::isInProgress((new ReflectionClass($resourceClass))->getFileName())) {
+        if (AnalyzedCache::isInProgress($file = (new ReflectionClass($resourceClass))->getFileName())) {
+            AnalyzedCache::noteCycle($file);
+
             return null;
         }
 

--- a/src/NodeResolvers/Expr/Ternary.php
+++ b/src/NodeResolvers/Expr/Ternary.php
@@ -31,6 +31,9 @@ class Ternary extends AbstractResolver
                 ->whenFalse(fn ($_, TypeContract $type) => $type->nullable(true));
         }
 
+        // These are the narrowed types of the value the condition tests, not
+        // the types of the branches. Record them so each branch resolves
+        // against what the condition proved, then take the branches' own types.
         $if = $result->apply();
         $else = $result->toggle()->apply();
 
@@ -38,11 +41,15 @@ class Ternary extends AbstractResolver
             $this->scope->state()->add($node->if, $if);
         }
 
+        $ifType = $this->from($node->if);
+
         if ($this->scope->state()->canHandle($node->else)) {
             $this->scope->state()->add($node->else, $else);
         }
 
-        return Type::union($if, $else);
+        $elseType = $this->from($node->else);
+
+        return Type::union($ifType, $elseType);
     }
 
     public function resolveForCondition(Node\Expr\Ternary $node)

--- a/tests/Unit/Analyzer/AnalyzedCacheTest.php
+++ b/tests/Unit/Analyzer/AnalyzedCacheTest.php
@@ -32,8 +32,26 @@ function resetCacheDirectory(): void
     $depsProp = $reflection->getProperty('dependencies');
     $depsProp->setValue(null, []);
 
+    // A test that fails mid-analysis leaves a frame open, which would then
+    // attach its dependencies to whatever runs next.
+    foreach (['frames', 'framePaths', 'frameTainted', 'deferred'] as $property) {
+        $reflection->getProperty($property)->setValue(null, []);
+    }
+
+    $reflection->getProperty('cycleFloor')->setValue(null, null);
+
     $keyProp = $reflection->getProperty('key');
     $keyProp->setValue(null, null);
+}
+
+/**
+ * @return list<string>
+ */
+function dependenciesFor(string $path): array
+{
+    $dependencies = (new ReflectionProperty(AnalyzedCache::class, 'dependencies'))->getValue();
+
+    return array_keys($dependencies[$path] ?? []);
 }
 
 function createCacheDir(): string
@@ -499,26 +517,61 @@ describe('in-progress tracking', function () {
 });
 
 describe('dependency tracking', function () {
-    it('tracks dependencies', function () {
+    it('tracks dependencies against the file being analyzed', function () {
+        AnalyzedCache::beginAnalysis('/path/to/main.php');
         AnalyzedCache::addDependency('/path/to/dep1.php');
         AnalyzedCache::addDependency('/path/to/dep2.php');
+        AnalyzedCache::endAnalysis('/path/to/main.php');
 
-        $reflection = new ReflectionClass(AnalyzedCache::class);
-        $depsProp = $reflection->getProperty('dependencies');
-
-        $deps = array_keys($depsProp->getValue());
-        expect($deps)->toContain('/path/to/dep1.php');
-        expect($deps)->toContain('/path/to/dep2.php');
+        expect(dependenciesFor('/path/to/main.php'))
+            ->toContain('/path/to/dep1.php')
+            ->toContain('/path/to/dep2.php');
     });
 
     it('does not record a dependency twice', function () {
+        AnalyzedCache::beginAnalysis('/path/to/main.php');
         AnalyzedCache::addDependency('/path/to/dep1.php');
         AnalyzedCache::addDependency('/path/to/dep1.php');
+        AnalyzedCache::endAnalysis('/path/to/main.php');
 
-        $reflection = new ReflectionClass(AnalyzedCache::class);
-        $depsProp = $reflection->getProperty('dependencies');
+        expect(dependenciesFor('/path/to/main.php'))->toBe(['/path/to/dep1.php']);
+    });
 
-        expect(array_keys($depsProp->getValue()))->toBe(['/path/to/dep1.php']);
+    it('does not record a dependency against an unrelated file', function () {
+        AnalyzedCache::beginAnalysis('/path/to/first.php');
+        AnalyzedCache::addDependency('/path/to/dep1.php');
+        AnalyzedCache::endAnalysis('/path/to/first.php');
+
+        AnalyzedCache::beginAnalysis('/path/to/second.php');
+        AnalyzedCache::addDependency('/path/to/dep2.php');
+        AnalyzedCache::endAnalysis('/path/to/second.php');
+
+        expect(dependenciesFor('/path/to/second.php'))->toBe(['/path/to/dep2.php']);
+    });
+
+    it('gives a file the dependencies of the files it depends on', function () {
+        AnalyzedCache::beginAnalysis('/path/to/a.php');
+        AnalyzedCache::addDependency('/path/to/b.php');
+
+        AnalyzedCache::beginAnalysis('/path/to/b.php');
+        AnalyzedCache::addDependency('/path/to/c.php');
+        AnalyzedCache::endAnalysis('/path/to/b.php');
+
+        AnalyzedCache::endAnalysis('/path/to/a.php');
+
+        expect(dependenciesFor('/path/to/a.php'))
+            ->toContain('/path/to/b.php')
+            ->toContain('/path/to/c.php');
+
+        expect(dependenciesFor('/path/to/b.php'))->toBe(['/path/to/c.php']);
+    });
+
+    it('does not record a file as depending on itself', function () {
+        AnalyzedCache::beginAnalysis('/path/to/a.php');
+        AnalyzedCache::addDependency('/path/to/a.php');
+        AnalyzedCache::endAnalysis('/path/to/a.php');
+
+        expect(dependenciesFor('/path/to/a.php'))->toBe([]);
     });
 
     it('stores dependencies when persisting to disk', function () {
@@ -528,11 +581,14 @@ describe('dependency tracking', function () {
         $mainFixture = createTestClassFixture('MainClass', 'public function main() {}');
         $depFixture = createTestClassFixture('DepClass', 'public function dep() {}');
 
+        AnalyzedCache::beginAnalysis($mainFixture);
         AnalyzedCache::addDependency($depFixture);
 
         $scope = new Scope;
         $scope->setPath($mainFixture);
         AnalyzedCache::add($mainFixture, $scope);
+
+        AnalyzedCache::endAnalysis($mainFixture);
 
         $cacheFiles = glob($dir.'/*.cache');
         expect($cacheFiles)->toHaveCount(1);
@@ -557,11 +613,14 @@ describe('dependency tracking', function () {
         $mainFixture = createTestClassFixture('MainClass', 'public function main() {}');
         $depFixture = createTestClassFixture('DepClass', 'public function dep() {}');
 
+        AnalyzedCache::beginAnalysis($mainFixture);
         AnalyzedCache::addDependency($depFixture);
 
         $scope = new Scope;
         $scope->setPath($mainFixture);
         AnalyzedCache::add($mainFixture, $scope);
+
+        AnalyzedCache::endAnalysis($mainFixture);
 
         AnalyzedCache::clearMemory();
 
@@ -584,11 +643,14 @@ describe('dependency tracking', function () {
         $mainFixture = createTestClassFixture('MainClass', 'public function main() {}');
         $depFixture = createTestClassFixture('DepClass', 'public function dep() {}');
 
+        AnalyzedCache::beginAnalysis($mainFixture);
         AnalyzedCache::addDependency($depFixture);
 
         $scope = new Scope;
         $scope->setPath($mainFixture);
         AnalyzedCache::add($mainFixture, $scope);
+
+        AnalyzedCache::endAnalysis($mainFixture);
 
         AnalyzedCache::clearMemory();
 
@@ -603,6 +665,116 @@ describe('dependency tracking', function () {
 
         unlink($mainFixture);
         unlink($depFixture);
+        cleanupCacheDir($dir);
+    });
+
+    it('invalidates cache when an indirect dependency changes', function () {
+        $dir = createCacheDir();
+        AnalyzedCache::enableDiskCache($dir);
+
+        $a = createTestClassFixture('AClass', 'public function a() {}');
+        $b = createTestClassFixture('BClass', 'public function b() {}');
+        $c = createTestClassFixture('CClass', 'public function c() {}');
+
+        // A uses B, B uses C. Nothing links A to C directly.
+        AnalyzedCache::beginAnalysis($a);
+        AnalyzedCache::addDependency($b);
+
+        AnalyzedCache::beginAnalysis($b);
+        AnalyzedCache::addDependency($c);
+        AnalyzedCache::add($b, tap(new Scope, fn ($scope) => $scope->setPath($b)));
+        AnalyzedCache::endAnalysis($b);
+
+        AnalyzedCache::add($a, tap(new Scope, fn ($scope) => $scope->setPath($a)));
+        AnalyzedCache::endAnalysis($a);
+
+        AnalyzedCache::clearMemory();
+
+        expect(AnalyzedCache::get($a))->not->toBeNull();
+
+        sleep(1);
+        file_put_contents($c, "<?php\nclass CClass { public function modified() {} }");
+
+        AnalyzedCache::clearMemory();
+
+        expect(AnalyzedCache::get($a))->toBeNull();
+
+        unlink($a);
+        unlink($b);
+        unlink($c);
+        cleanupCacheDir($dir);
+    });
+
+    it('invalidates every member of a cycle when one of them changes', function () {
+        $dir = createCacheDir();
+        AnalyzedCache::enableDiskCache($dir);
+
+        $a = createTestClassFixture('CycleA', 'public function a() {}');
+        $b = createTestClassFixture('CycleB', 'public function b() {}');
+
+        // A uses B, and B uses A again while A is still being analyzed.
+        AnalyzedCache::beginAnalysis($a);
+        AnalyzedCache::addDependency($b);
+
+        AnalyzedCache::beginAnalysis($b);
+        AnalyzedCache::addDependency($a);
+        AnalyzedCache::noteCycle($a);
+        AnalyzedCache::add($b, tap(new Scope, fn ($scope) => $scope->setPath($b)));
+        AnalyzedCache::endAnalysis($b);
+
+        AnalyzedCache::add($a, tap(new Scope, fn ($scope) => $scope->setPath($a)));
+        AnalyzedCache::endAnalysis($a);
+
+        AnalyzedCache::clearMemory();
+
+        expect(AnalyzedCache::get($a))->not->toBeNull();
+        expect(AnalyzedCache::get($b))->not->toBeNull();
+
+        // B is cached against A, even though A is the file that came first.
+        expect(dependenciesFor($b))->toContain($a);
+
+        sleep(1);
+        file_put_contents($a, "<?php\nclass CycleA { public function modified() {} }");
+
+        AnalyzedCache::clearMemory();
+
+        expect(AnalyzedCache::get($b))->toBeNull();
+
+        unlink($a);
+        unlink($b);
+        cleanupCacheDir($dir);
+    });
+
+    it('does not record dependencies against unrelated files analyzed later', function () {
+        $dir = createCacheDir();
+        AnalyzedCache::enableDiskCache($dir);
+
+        $first = createTestClassFixture('FirstClass', 'public function first() {}');
+        $dep = createTestClassFixture('SharedDep', 'public function dep() {}');
+        $later = createTestClassFixture('LaterClass', 'public function later() {}');
+
+        AnalyzedCache::beginAnalysis($first);
+        AnalyzedCache::addDependency($dep);
+        AnalyzedCache::add($first, tap(new Scope, fn ($scope) => $scope->setPath($first)));
+        AnalyzedCache::endAnalysis($first);
+
+        AnalyzedCache::beginAnalysis($later);
+        AnalyzedCache::add($later, tap(new Scope, fn ($scope) => $scope->setPath($later)));
+        AnalyzedCache::endAnalysis($later);
+
+        AnalyzedCache::clearMemory();
+
+        sleep(1);
+        file_put_contents($first, "<?php\nclass FirstClass { public function modified() {} }");
+
+        AnalyzedCache::clearMemory();
+
+        expect(AnalyzedCache::get($first))->toBeNull();
+        expect(AnalyzedCache::get($later))->not->toBeNull();
+
+        unlink($first);
+        unlink($dep);
+        unlink($later);
         cleanupCacheDir($dir);
     });
 });

--- a/tests/Unit/AnalyzerTest.php
+++ b/tests/Unit/AnalyzerTest.php
@@ -651,9 +651,15 @@ class AfterEmptyPath
         $analyzer->analyze('');
         $analyzer->analyze($fixture);
 
-        $dependencies = new ReflectionProperty(AnalyzedCache::class, 'dependencies');
+        $dependencies = (new ReflectionProperty(AnalyzedCache::class, 'dependencies'))->getValue();
 
-        expect($dependencies->getValue())->toBe([]);
+        // The empty path must not leave a frame open, which would make the
+        // second call look like a dependency of the first.
+        foreach ($dependencies as $path => $paths) {
+            expect(array_keys($paths))->not->toContain($fixture);
+        }
+
+        expect($dependencies[$fixture] ?? [])->toBe([]);
 
         unlink($fixture);
     });

--- a/tests/Unit/Resolvers/TernaryTest.php
+++ b/tests/Unit/Resolvers/TernaryTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use Laravel\Surveyor\Analyzer\AnalyzedCache;
+use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Types\ArrayType;
+use Laravel\Surveyor\Types\IntType;
+use Laravel\Surveyor\Types\StringType;
+use Laravel\Surveyor\Types\UnionType;
+
+uses()->group('integration');
+
+beforeEach(function () {
+    AnalyzedCache::clear();
+
+    app()->forgetInstance(Analyzer::class);
+});
+
+afterEach(function () {
+    AnalyzedCache::clear();
+});
+
+function ternaryReturnType(string $body)
+{
+    $fixture = createPhpFixture('
+namespace App\\Test;
+
+class TernarySubject
+{
+    public function target(string $input)
+    {
+        '.$body.'
+    }
+}');
+
+    $result = app(Analyzer::class)->analyze($fixture)->result();
+
+    unlink($fixture);
+
+    return $result->getMethod('target')->returnType();
+}
+
+describe('Ternary resolver', function () {
+    it('returns the types of the branches, not of the compared value', function () {
+        $type = ternaryReturnType("return \$input === 'request' ? 1 : 2;");
+
+        $types = $type instanceof UnionType ? $type->types : [$type];
+
+        foreach ($types as $inner) {
+            expect($inner)->toBeInstanceOf(IntType::class);
+        }
+    });
+
+    it('does not leak a compared literal that names a loadable class', function () {
+        // `Request` exists case-insensitively, so a leaked `request` literal
+        // resolves to a class and reaches generated output as a fake response.
+        $type = ternaryReturnType("return \$input === 'request' ? 'yes' : 'no';");
+
+        $types = $type instanceof UnionType ? $type->types : [$type];
+
+        expect(array_map(fn ($inner) => $inner->id(), $types))
+            ->not->toContain('request');
+
+        foreach ($types as $inner) {
+            expect($inner)->toBeInstanceOf(StringType::class);
+        }
+    });
+
+    it('keeps the compared value usable as a branch', function () {
+        $type = ternaryReturnType("return \$input === 'yes' ? \$input : 'no';");
+
+        $types = $type instanceof UnionType ? $type->types : [$type];
+
+        foreach ($types as $inner) {
+            expect($inner)->toBeInstanceOf(StringType::class);
+        }
+    });
+
+    it('gives a truthiness check the shape of its branches', function () {
+        // The shape Laravel controllers use constantly: build an array when a
+        // value is present, null when it is not. The array shape is what the
+        // key carries, not the type of the value under test.
+        $type = ternaryReturnType("return \$input ? ['name' => 'a', 'size' => 1] : null;");
+
+        $types = $type instanceof UnionType ? $type->types : [$type];
+
+        $shapes = array_values(array_filter($types, fn ($inner) => $inner instanceof ArrayType));
+
+        expect($shapes)->toHaveCount(1);
+        expect(array_keys($shapes[0]->value))->toBe(['name', 'size']);
+    });
+
+    it('resolves both sides of a nested ternary', function () {
+        $type = ternaryReturnType("return \$input === 'a' ? 1 : (\$input === 'b' ? 2 : 3);");
+
+        $types = $type instanceof UnionType ? $type->types : [$type];
+
+        foreach ($types as $inner) {
+            expect($inner)->toBeInstanceOf(IntType::class);
+        }
+    });
+
+    it('still resolves the short form to its one branch', function () {
+        $type = ternaryReturnType("return \$input ?: 'fallback';");
+
+        $types = $type instanceof UnionType ? $type->types : [$type];
+
+        foreach ($types as $inner) {
+            expect($inner)->toBeInstanceOf(StringType::class);
+        }
+    });
+});


### PR DESCRIPTION
The dependency list behind the cache was global and only ever grew, so every entry written after a file was first touched carried it as a dependency and died with it. Editing one file threw away 1796 of 3078 entries. Each path now records its own dependency closure, so the same edit throws away 283.