### PR TITLE
Stop string literals from becoming class types

### DIFF
--- a/src/Support/Util.php
+++ b/src/Support/Util.php
@@ -5,6 +5,7 @@ namespace Laravel\Surveyor\Support;
 use Illuminate\Support\Facades\Facade;
 use Laravel\Surveyor\Analysis\Scope;
 use ReflectionClass;
+use ReflectionException;
 
 class Util
 {
@@ -14,16 +15,60 @@ class Util
 
     public static function isClassOrInterface(string $value): bool
     {
-        // Check function_exists() and defined() before class_exists() to prevent
-        // the class autoloader from being triggered for namespaced functions that
-        // were already loaded via Composer's "autoload.files", which would cause
-        // a fatal "cannot redeclare function" error.
-        return self::$isClassOrInterface[$value] ??= function_exists($value)
-            || defined($value)
-            || class_exists($value)
-            || interface_exists($value)
-            || trait_exists($value)
-            || enum_exists($value);
+        return self::$isClassOrInterface[$value] ??= self::determineIsClassOrInterface($value);
+    }
+
+    protected static function determineIsClassOrInterface(string $value): bool
+    {
+        // Anything already loaded can be checked without the autoloader.
+        if (self::isDeclared($value, false)) {
+            return self::isSpelledLikeItsDeclaration($value);
+        }
+
+        // Asking class_exists() to autoload a name that Composer already
+        // pulled in as a namespaced function through "autoload.files" fatals
+        // with "cannot redeclare function". An unqualified name cannot reach
+        // that file, and bailing out on one would lose the facade aliases,
+        // whose names double as helper functions.
+        if (str_contains($value, '\\') && (function_exists($value) || defined($value))) {
+            return false;
+        }
+
+        return self::isDeclared($value, true) && self::isSpelledLikeItsDeclaration($value);
+    }
+
+    protected static function isDeclared(string $value, bool $autoload): bool
+    {
+        return class_exists($value, $autoload)
+            || interface_exists($value, $autoload)
+            || trait_exists($value, $autoload)
+            || enum_exists($value, $autoload);
+    }
+
+    /**
+     * PHP matches class names without regard to case, so the plain string
+     * 'request' finds the Request facade alias and every literal spelled like
+     * a class name becomes one.
+     */
+    protected static function isSpelledLikeItsDeclaration(string $value): bool
+    {
+        try {
+            $declared = (new ReflectionClass($value))->getName();
+        } catch (ReflectionException) {
+            return false;
+        }
+
+        $parts = explode('\\', $declared);
+        $short = end($parts);
+
+        if ($value === $declared || $value === $short) {
+            return true;
+        }
+
+        // An alias names a class that is genuinely spelled differently, so it
+        // is still a class reference. A name that matches only once case is
+        // ignored is not: that is an ordinary string colliding with a class.
+        return strcasecmp($value, $declared) !== 0 && strcasecmp($value, $short) !== 0;
     }
 
     public static function resolveValidClass(string $value, Scope $scope): string

--- a/tests/Unit/Support/UtilTest.php
+++ b/tests/Unit/Support/UtilTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Support\CaseProbe;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Laravel\Surveyor\Support\Util;
+use Laravel\Surveyor\Types\ClassType;
+use Laravel\Surveyor\Types\StringType;
+use Laravel\Surveyor\Types\Type;
+
+uses()->group('integration');
+
+describe('Util::isClassOrInterface', function () {
+    it('accepts a class written the way it is declared', function () {
+        expect(Util::isClassOrInterface(Request::class))->toBeTrue();
+        expect(Util::isClassOrInterface(Str::class))->toBeTrue();
+        expect(Util::isClassOrInterface(Util::class))->toBeTrue();
+    });
+
+    it('tells an alias apart from a differently cased spelling of it', function () {
+        if (! class_exists('CaseProbe', false)) {
+            class_alias(CaseProbe::class, 'CaseProbe');
+        }
+
+        // PHP finds a class whatever the case, so without this every string
+        // spelled like a class name becomes one.
+        expect(Util::isClassOrInterface('CaseProbe'))->toBeTrue();
+        expect(Util::isClassOrInterface('caseprobe'))->toBeFalse();
+    });
+
+    it('rejects a bare literal that collides with a facade alias', function () {
+        // The case that reached generated output: 'request' found the Request
+        // facade, resolved to Illuminate\Http\Request, and because that is
+        // Arrayable it was emitted as an empty JSON response.
+        expect(Util::isClassOrInterface('request'))->toBeFalse();
+        expect(Util::isClassOrInterface('view'))->toBeFalse();
+        expect(Util::isClassOrInterface('config'))->toBeFalse();
+    });
+});
+
+describe('Type::string', function () {
+    it('keeps ordinary literals as strings', function () {
+        foreach (['view', 'cache', 'request', 'config', 'value', 'now', 'banana'] as $literal) {
+            expect(Type::string($literal))
+                ->toBeInstanceOf(StringType::class, "expected '{$literal}' to stay a string");
+        }
+    });
+
+    it('still recognises real class names', function () {
+        expect(Type::string(Request::class))->toBeInstanceOf(ClassType::class);
+        expect(Type::string(Str::class))->toBeInstanceOf(ClassType::class);
+    });
+});

--- a/workbench/app/Support/CaseProbe.php
+++ b/workbench/app/Support/CaseProbe.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Exists so a test can register a global alias for it and check that a class
+ * is still recognised through the alias, while a differently cased spelling of
+ * the same name is not.
+ */
+class CaseProbe
+{
+    //
+}


### PR DESCRIPTION
`Util::isClassOrInterface()` returned true whenever `function_exists()` or `defined()` did, so any literal sharing a name with a loaded function became a class type: `view`, `cache`, `config`, `request` and a couple dozen more. PHP matches class names without regard to case too, so `'request'` found the `Request` facade, resolved to `Illuminate\Http\Request`, and since that is `Arrayable` it could be emitted as an empty JSON response.

Loaded types are now found without the autoloader, the `function_exists()` check goes back to being the autoload guard its comment always said it was and only applies to qualified names, and a name matching a class only once case is ignored is rejected.