### PR TITLE
Fix type inversion when removing a non-matching condition type

### DIFF
--- a/src/Analysis/Condition.php
+++ b/src/Analysis/Condition.php
@@ -97,7 +97,7 @@ class Condition
                 fn ($t) => ! Type::is($t, $type),
             ));
         } else {
-            $newType = Type::is($this->type, $type) ? Type::mixed() : $type;
+            $newType = Type::is($this->type, $type) ? Type::mixed() : $this->type;
         }
 
         $this->type = $newType;

--- a/tests/Unit/Analysis/ConditionTest.php
+++ b/tests/Unit/Analysis/ConditionTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Laravel\Surveyor\Analysis\Condition;
+use Laravel\Surveyor\Types\Type;
+use PhpParser\Node\Expr\Variable;
+
+it('preserves a non-union type when removing a different type', function () {
+    $originalType = Type::string();
+
+    $condition = Condition::from(new Variable('value'), $originalType)
+        ->removeType(Type::int());
+
+    expect($condition->type)->toBe($originalType);
+});

--- a/tests/Unit/Resolvers/ConditionNarrowingTest.php
+++ b/tests/Unit/Resolvers/ConditionNarrowingTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Laravel\Surveyor\Analyzer\AnalyzedCache;
+use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Types\IntType;
+use Laravel\Surveyor\Types\UnionType;
+
+uses()->group('integration');
+
+beforeEach(function () {
+    AnalyzedCache::clear();
+
+    app()->forgetInstance(Analyzer::class);
+});
+
+afterEach(function () {
+    AnalyzedCache::clear();
+});
+
+it('does not narrow a variable to the type a condition ruled out', function () {
+    $fixture = createPhpFixture('
+namespace App\Test;
+
+class NarrowingSubject
+{
+    public function target(bool $flag)
+    {
+        $value = "hi";
+
+        if (! is_int($value) && $flag) {
+            return $value;
+        }
+
+        return 1.5;
+    }
+}');
+
+    $type = app(Analyzer::class)->analyze($fixture)->result()->getMethod('target')->returnType();
+
+    unlink($fixture);
+
+    $types = $type instanceof UnionType ? $type->types : [$type];
+
+    expect($types)->each->not->toBeInstanceOf(IntType::class);
+});


### PR DESCRIPTION
This PR fixes `Condition::removeType()` incorrectly replacing a non-union type with the type being removed.

When the current type does not match the removal target, the original type is now preserved.
