### PR TITLE
Stop Type::union marking its arguments nullable in place

### DIFF
--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -232,13 +232,16 @@ class Type
             $hasNull = $hasNull || $type instanceof NullType;
         }
 
-        // Null is carried by marking the other members nullable.
+        // Null is carried by marking the other members nullable. The members
+        // belong to whoever passed them in, and one of them may be the type
+        // recorded for a model's property or a method's return, so they are
+        // copied before the flag is set rather than marked in place.
         if ($hasNull) {
             $nullable = [];
 
             foreach ($unique as $type) {
                 if (! $type instanceof NullType) {
-                    $nullable[] = $type->nullable();
+                    $nullable[] = $type->isNullable() ? $type : (clone $type)->nullable();
                 }
             }
 


### PR DESCRIPTION
Type::union() carries a null member by marking the other members nullable, but it was setting the flag on the objects it was handed rather than on copies. Those objects belong to the caller, and one of them can be the type already recorded for a model property or a method return, so resolving an unrelated union somewhere else in the codebase would permanently flip a stored type to nullable.

The visible effect was that a cold run and a warm run of the same unchanged code produced different output. Reading a cached analysis goes through unserialize(), which hands back a fresh object graph, so the shared object could not be reached and the warm result was correct. A cold run shared the live object and got it wrong. On a large application this showed up as nullable route keys and unnecessary null guards on a handful of routes, meaning CI output did not match local output.

Union now copies before setting the flag. Cold and warm builds of the same tree now produce identical output.
