### PR TITLE
Make analysis deterministic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 vendor
 examples
+
+# Scratch caches and generated output left behind by benchmarks/cache scripts
+benchmarks/cache/*/
+benchmarks/cache/*.orig
+benchmarks/cache/*.diff
+benchmarks/cache/*.patch

--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -1,0 +1,275 @@
+# Warm path performance: findings and plan
+
+Everything here was measured on `laravel/cloud` (3,108 PHP files in `app/`, 617
+routes, PHP 8.5.8, 12 cores) by running `php artisan wayfinder:generate`.
+Numbers are medians of repeated runs with the analysis cache settled first.
+Where something is a calculation rather than a measurement it says so.
+
+## Where it stands
+
+| | before this work | after discovery and caching | after determinism |
+|---|---|---|---|
+| cold, empty cache | 17.4s | 15.6s | 18.8s |
+| warm, nothing changed | 4.6s | 1.24s | 1.28s |
+| warm, one edit to `Instance.php` | 7.0s | 3.8s | 4.1s |
+
+The first column predates all of this. The other two are medians of three runs
+each, taken back to back on the same machine.
+
+Which file you edit still decides the edit path, and closing that spread is what
+step 2 below is for:
+
+| touched | entries rewritten (of 3,149) | time |
+|---|---|---|
+| `app/Models/Instance.php` | 258 | 3.7s |
+| `app/Models/User.php` | 1,370 | 11.2s |
+| `app/Models/Environment.php` | 1,366 | 16.9s |
+| `app/Models/Organization.php` | 1,370 | 19.5s |
+
+One run each. Before the determinism work the same four measured 3.9s, 9.1s,
+15.2s and 16.3s against a nearly identical count of rewritten entries, so
+settling the cycles costs on the edit path too, everywhere except the file whose
+dependents are few.
+
+Analysis is now deterministic: the same bytes give the same answers whatever
+order the files are visited in. That was the blocker on fingerprinting, so
+step 2 can start.
+
+## What landed
+
+**Ranger v0.4.0, one shared structure index.** Five collectors each ran their
+own `Discover::in()` over the whole application, so every build read all 3,108
+files five times. Instrumenting `Discover::get()` in a real run: five calls,
+3.718s of a 4.76s build, whether or not anything had changed. `Support\Inventory`
+now reads the paths once and remembers what it found per file, so a build pays
+only for files that changed. Discovery went from 0.744s to 0.026s warm. Output
+byte identical, checked field by field against the old path over all 3,108 files.
+
+**Surveyor `Type::union` no longer marks its arguments nullable in place.**
+It set the flag on the objects it was handed, and one of those can be the type
+already recorded for a model property. Resolving an unrelated union then flipped
+a stored type to nullable for the rest of the run. Reading a cached analysis goes
+through `unserialize()`, which hands back a fresh graph, so warm builds could not
+reach the shared object and were correct while cold builds were wrong. Cold and
+warm output differed by 124 lines across 6 files, showing up as nullable route
+keys and needless null guards. Now zero.
+
+**Wayfinder sets Ranger's cache directory** and clears it on `--fresh`. Without
+this Ranger writes no index and none of the above applies.
+
+## Determinism: what it was, and what fixed it
+
+Four changes, in the working tree, not yet committed. Together: no flapping
+surfaces on any target measured, warm output equal to cold across every shape
+of source change, 288 tests passing, and 15 generated declarations that used to
+name a type nothing declared now carry the real shape.
+
+**One traverser per parse.** This was the whole of it. `Parser` added a
+`NameResolver` and a `TypeResolver` to a single `NodeTraverser` in its
+constructor, and `Analyzer` is a singleton holding one `Parser`. Resolving a
+node can analyze another file, which lands back in `Parser::parseCode()` while
+the outer traversal is still running, so the nested file walked the same
+traverser and the same two visitors. php-parser's `NameResolver` starts each
+traversal with a fresh `NameContext`, so when control came back the outer file's
+remaining names resolved against the nested file's imports.
+
+What that looked like in the wild: `app/Support/DeploymentLogParser.php` imports
+`Illuminate\Support\Carbon` and has `timeSince(?Carbon $startedAt)`. On a cold
+build the recorded parameter type was `App\Support\Carbon`, a different class
+that also exists. Once the imports are gone, `Scope::getUse()` guesses the
+file's own namespace before it walks up to the parent scope that holds the
+imports, and the guess exists, so it wins. A warm build parses fewer files, so
+nothing clobbered the context and the answer was right. Same bytes, two answers.
+
+Touching `app/Models/User.php` without changing a byte, then rebuilding: 8 of
+3,158 entries came back with a different public surface, every one of them a
+short class name landing on a different fully qualified name. Three were read
+line by line, `Carbon`, `Builder` and `DatabaseSnapshot`, and in all three the
+cold answer was the wrong one, resolved against some other file's imports.
+
+Each parse now builds its own traverser and visitors. That took the 8 to 1, and
+dropped 10 vendor files from the build, files only ever reached because a name
+resolved to the wrong class.
+
+**Cycle members are analyzed again once the cycle closes.** The one remaining
+flap was the empty-scope bail-out already described below. A cold build has
+1,763 of them across 80 cycles, and the cycles hold 333 members between them.
+`app/Models/Zone.php` is the root of one cycle with 91 members, `Environment.php`
+among them, which is why `Environment::vanityDomainZone()` recorded `mixed` for
+`Zone::freeTrial()` on a cold build and `App\Models\Zone` on a warm one: a method
+returning `static` resolves against the scope of the class it was found on, and
+during a cycle that scope is empty.
+
+`AnalyzedCache` already knew which entries it had held back while a cycle was
+open. It now hands that list to the analyzer, which invalidates and re-analyzes
+one member at a time with the rest left in the cache, so each of them sees a
+finished answer for everything it reaches. That is the cheap spike the plan
+asked for, and it worked: no surface flaps left. It costs 333 extra analyses,
+which is the 15.6s to 18.8s on the cold column above, and 2 to 3s on the edit
+path for a file with many dependents. Editing `Instance.php` rewrites fewer
+entries than it used to, 258 against 312, because a dependency list recorded
+outside a cycle is narrower, but that does not show up as time saved.
+
+**Fluent calls keep their receiver.** Settling the cycles made
+`DeploymentResource::make($x)->forParentEnvironment($y)` resolve, and the answer
+came back as a bare class name where the generated types then had nothing to
+point at. `forParentEnvironment(): static` returns the object it was called on,
+but reflection only reports which class that is, so the resource response and
+the shape it carries were thrown away and replaced with a plain class. A method
+call whose reflected return type is the same class as its receiver now hands the
+receiver straight back when the receiver knows more than its class name.
+
+It also fixed three references that were dangling before any of this work:
+`App.Http.Resources.Dashboard.EnvironmentResource`, `CacheResource` and
+`FilesystemResource` were named in the generated types and declared nowhere. 15
+declarations gained a real shape, one new response type appeared, and nothing
+was lost. One dangling name is left, `NonWrappedCollection`.
+
+**The reflector puts the scope back.** `Reflector::methodReturnType` swapped the
+shared reflector's scope to another class's scope and never restored it, so the
+next file resolved its own short class names against whatever class was looked at
+last. The generics branch a few lines below already had a `$scopeToRestore`
+guard, so the hazard was known. Restoring it before determinism landed made
+things worse, which is why it was parked. Done after: output byte identical,
+determinism still clean, all tests pass.
+
+## Plan
+
+1. ~~**Determinism.**~~ Done, above. The deliverable is
+   `tests/Unit/Analyzer/DeterminismTest.php` with fixtures in
+   `workbench/app/Determinism`: one test that a file's own imports survive
+   analyzing another file, one that the surface is the same whichever file is
+   analyzed first, one that a cycle member is answered against the finished
+   analysis of the other member. Each fails without the change it covers.
+
+2. **Fingerprint invalidation.** Store **direct** dependencies only, each keyed
+   by that dependency's public surface hash rather than its modification time or
+   its bytes. A body edit changes the file's own hash so that file is
+   re-analysed, its surface is unchanged, so its dependents stay valid.
+
+   Measured ceiling, on a settled cache:
+
+   | edit | re-analysed | results that changed |
+   |---|---|---|
+   | `touch User.php`, bytes identical | 1,374 | 5 |
+   | `Environment.php` body-only edit | 1,370 | 5 |
+   | `Environment.php` new public method | 1,370 | 1 |
+
+   So 99.6% of the re-analysis produces byte identical results. Adding a public
+   method changed exactly one surface, the edited file's own, which is the
+   property the design needs. At roughly 9.6ms per entry that is about 13s of
+   wasted work on a central model. This is a ceiling from measured redundancy,
+   not a measurement of an implementation.
+
+   Cache size falls out of this for free. Of 272MB, 85% is dependency
+   bookkeeping: 1.6M path and mtime pairs. Dependencies **recorded** per entry:
+   median 92, mean 489, max 1,803. Dependencies **actually used**: median 2,
+   mean 4, max 63. The closure is 129 times the direct edges, so direct edges
+   take the cache to roughly 42MB.
+
+   Note why the closure is there: the comment in `AnalyzedCache` says it is
+   stored flat so an entry can be validated by stat'ing a list without walking
+   the graph. Direct edges break that unless validity is decided by the
+   dependency's surface hash, which keeps the check one level deep. That needs a
+   small side index of path to surface hash so a dependency can be checked
+   without loading its whole entry.
+
+   `benchmarks/cache/surfacedump.php` already computes the surface of every
+   entry in a cache directory, and its `--fields` mode hashes each `Scope`
+   property on its own. Whatever the fingerprint ends up hashing should agree
+   with what that script calls a surface, or one of the two is wrong.
+
+3. **Loose ends, any time.** A regression test for the `Type::union` fix. It
+   needs a shared type object reachable from two places, which no current test
+   sets up. Debouncing the Vite plugin, which today runs one full build per saved
+   file, serially.
+
+   `StateTracker` is serialised into every cache entry. It holds the variable
+   state of the run that produced the entry, nothing reads it back, and it is
+   the only thing that still differs between two analyses of the same bytes: 3
+   of 3,149 entries after editing `Organization.php`. Dropping it from what gets
+   persisted would shrink the cache and take those 3 to zero.
+
+## Dead ends, with numbers
+
+Recorded so nobody spends a day on them again.
+
+| idea | why not |
+|---|---|
+| A class-existence oracle | `Util::isClassOrInterface` costs 1.04s of a 17.4s cold run. 92,339 probes, 85,675 of them misses, 4.4us each, so the misses are 0.374s. An earlier version of this analysis claimed 34% of the cold run, taken from a sampling profiler. That was wrong. |
+| Caching method return types | 101,505 calls for 17,254 distinct `class::method` pairs looks like 83% waste. The repeats cost 0.84s; the first-time lookups cost 9.93s. 123 keys also legitimately return different answers at different call sites, all generic containers like `Collection::all`. |
+| Cheaper dependency bookkeeping | `addDependency` merges 35,363,504 closure entries per run and costs 0.13s. PHP's array union is fast. The size matters for disk and for invalidation width, not for CPU. |
+| Reusing resolver instances | A fresh resolver is built for each of 1.9M node visits. Building all of them costs 0.17s, and reusing one while calling `setScope` measured slower. |
+| Sharing the traverser between parses | It is what made analysis order dependent, and it bought nothing: building a traverser and two visitors per parse does not show up against a 15s cold run. |
+| Passing changed paths in | Modification times already answer "what changed" for about 0.08s a build. Every real cost is downstream of knowing. Worth having only for a resident process, which has no sweep to fall back on. |
+| Shrinking the cache on its own | 0.76s on the write side, 0.13 to 0.22s on the read side, and it fixes itself with fingerprinting. |
+| Opcache CLI file cache | Slower. Boot 0.34s to 0.58s, warm build 4.54s to 4.71s. |
+| A faster serializer | The full 272MB cache reads and unserialises in 0.70s, about 1.18 GB/s. |
+| Tokenizer or php-parser work | Tokenising all 3,108 app files costs 0.068s. php-parser's `doParse` is under 1% of a cold run. |
+
+## Where cold time actually goes
+
+Instrumented per resolver with nested time subtracted, so these are exclusive:
+
+| resolver | exclusive | visits | each |
+|---|---|---|---|
+| `Expr\MethodCall` | 3.59s | 98,589 | 36us |
+| `Expr\StaticCall` | 2.40s | 25,918 | 93us |
+| `Param` | 1.03s | 31,447 | 33us |
+| `Expr\PropertyFetch` | 0.80s | 71,345 | 11us |
+| 146 others | 5.5s | 1.7M | |
+
+13.36s across 1,900,550 node visits and 150 resolver types. Method and static
+call resolution is 45% of it, and inside those the time is recursion into other
+files to find out what a call returns, not parsing and not reflection. There is
+no hotspot on the cold path. Making it faster means doing less work, and unlike
+the edit path there is no measured redundancy to remove. Settling the cycles
+added 333 analyses on top, about 3.2s; that is the one place where cold work
+could be trimmed, by settling fewer members or by splitting analysis into a
+surface pass and a body pass so a partial answer is never observable. Otherwise
+revisit only if CI time becomes the complaint.
+
+## How to measure
+
+All of these live in `benchmarks/cache`. They drive the app one build at a
+time; two of them running at once will quietly ruin both, and a stray build
+alongside a timing run reads as a regression.
+
+- `determinism.sh <label> [target]` builds a cold cache, touches one file
+  without changing it, rebuilds, and reports how many entries came back with a
+  different surface. Zero is the bar.
+- `surfacedump.php <cache-dir> [--detail|--fields]` renders a cache directory
+  as canonical text: one hash per entry, the surface lines themselves, or a
+  hash per `Scope` property to say which part of an entry moved.
+- `timeit.sh <label> [src-dir] [repeats]` copies a source tree into the app's
+  vendor directory and times cold, warm and warm plus edit. Point it at
+  snapshots of two trees to compare them.
+- `shapesweep.sh <label>` checks warm output against cold across append,
+  remove, edit, add, delete and rename. It is the guardrail for fingerprinting:
+  if warm and cold disagree, the fingerprints are wrong.
+- `bench.sh` and `sweepcmp.sh` predate the above and still work. Both call
+  `git checkout --` inside the app, so uncommitted work there will be lost.
+  `shapesweep.sh` no longer does; it copies the files it edits and puts them
+  back.
+
+The app loads Surveyor from `vendor`, not from this checkout, so a change here
+reaches a build only after `rsync -a --delete src/ <app>/vendor/laravel/surveyor/src/`.
+`determinism.sh` and `timeit.sh` do that themselves.
+
+Two habits that this work depended on:
+
+- **Settle the cache before timing.** Run until no entries are rewritten.
+  Otherwise the first run reads as a regression.
+- **Establish a noise floor.** Run unchanged code twice and diff the output
+  before trusting any comparison.
+
+**Do not trust a sampling profiler here.** PHP delivers async signals at VM
+instruction boundaries, which piles samples onto internal calls. A sampler put
+`file_get_contents` at 72% of a warm run when reading every file in the tree
+actually takes 0.05s, and put class-existence checks at 34% of a cold run when
+they cost 1.04s. Every number in this document that matters came from wrapping
+the suspect code in `hrtime()` counters in a real run. The trick for doing that
+without touching the repo: `php -d auto_prepend_file=probe.php`, where the probe
+requires `vendor/autoload.php` and then requires a patched copy of the class you
+want to instrument, so it is declared before Composer can autoload the original.
+That does not reach a subprocess, so it will not work on tests that shell out.

--- a/benchmarks/cache/determinism.sh
+++ b/benchmarks/cache/determinism.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Does re-analysing the same bytes give the same answer?
+#
+# Builds a cold cache, touches one file without changing it, then rebuilds. Any
+# entry whose canonical surface changed between the two runs is a flap: the same
+# source analysed twice, two answers.
+#
+# Usage: determinism.sh <label> [target-relative-path]
+
+set -u
+
+S="$(cd "$(dirname "$0")" && pwd)"
+SUR=/Users/joetannenbaum/Dev/surveyor
+APP=/Users/joetannenbaum/Herd/cloud
+LABEL=$1
+TARGET=${2:-app/Models/User.php}
+
+CACHE=$S/dt-$LABEL-cache
+KEEP=$S/dt-$LABEL
+
+cd "$APP" || exit 1
+
+# Nothing here edits app source, it only touches a file, so a dirty tree is
+# reported rather than treated as fatal.
+if ! git diff --quiet; then
+  echo "note: cloud has modified tracked files:"
+  git diff --name-only | sed 's/^/  /'
+fi
+
+# The app loads Surveyor from vendor, so the working tree has to be copied in.
+rsync -a --delete "$SUR/src/" "$APP/vendor/laravel/surveyor/src/"
+
+rm -rf "$KEEP"; mkdir -p "$KEEP"
+rm -rf "$CACHE"; mkdir -p "$CACHE"
+
+run() {
+  local out=$1
+  rm -rf "$out"; mkdir -p "$out"
+  WAYFINDER_CACHE_DIRECTORY=$CACHE php artisan wayfinder:generate --path="$out" > /dev/null 2>&1
+}
+
+echo "cold build..."
+run "$KEEP/out-cold"
+php "$S/surfacedump.php" "$CACHE" > "$KEEP/dump-a"
+php "$S/surfacedump.php" "$CACHE" --detail > "$KEEP/detail-a"
+php "$S/surfacedump.php" "$CACHE" --fields --detail > "$KEEP/fields-a"
+find "$CACHE" -name '*.cache' -exec stat -f '%N %m' {} \; | sort > "$KEEP/mtimes-a"
+echo "  $(wc -l < "$KEEP/dump-a" | tr -d ' ') entries"
+
+sleep 1
+touch "$APP/$TARGET"
+
+echo "warm build after touching $TARGET..."
+run "$KEEP/out-warm"
+php "$S/surfacedump.php" "$CACHE" > "$KEEP/dump-b"
+php "$S/surfacedump.php" "$CACHE" --detail > "$KEEP/detail-b"
+php "$S/surfacedump.php" "$CACHE" --fields --detail > "$KEEP/fields-b"
+find "$CACHE" -name '*.cache' -exec stat -f '%N %m' {} \; | sort > "$KEEP/mtimes-b"
+
+rewritten=$(comm -13 "$KEEP/mtimes-a" "$KEEP/mtimes-b" | wc -l | tr -d ' ')
+
+mask() {
+  find "$1" -type f -exec sed -i '' -E 's/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z?/<TS>/g' {} \;
+}
+mask "$KEEP/out-cold"; mask "$KEEP/out-warm"
+outdiff=$(diff -r "$KEEP/out-cold" "$KEEP/out-warm" | grep -c '^[<>]')
+
+python3 - "$KEEP/dump-a" "$KEEP/dump-b" "$rewritten" "$outdiff" <<'PY'
+import sys
+
+a_path, b_path, rewritten, outdiff = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+
+def load(path):
+    rows = {}
+    for line in open(path):
+        p, surface, entry, deps = line.rstrip("\n").split("\t")
+        rows[p] = (surface, entry)
+    return rows
+
+A, B = load(a_path), load(b_path)
+shared = set(A) & set(B)
+
+surface = sorted(p for p in shared if A[p][0] != B[p][0])
+entry = sorted(p for p in shared if A[p][1] != B[p][1])
+
+print()
+print(f"entries          {len(A)} cold, {len(B)} warm")
+print(f"only in cold     {len(set(A) - set(B))}")
+print(f"only in warm     {len(set(B) - set(A))}")
+print(f"rewritten        {rewritten}")
+print(f"entry flaps      {len(entry)}")
+print(f"surface flaps    {len(surface)}")
+print(f"output diff      {outdiff} lines")
+print()
+for p in surface:
+    print("  surface", p)
+for p in entry:
+    if p not in surface:
+        print("  entry  ", p)
+PY
+
+echo "fields that moved (entry, count):"
+diff "$KEEP/fields-a" "$KEEP/fields-b" | grep '^<' | awk '{print $4}' | sort | uniq -c | sort -rn | sed 's/^/  /'
+
+echo
+echo "kept: $KEEP"
+echo "surface detail: diff <(grep -F <path> $KEEP/detail-a) <(grep -F <path> $KEEP/detail-b)"

--- a/benchmarks/cache/shapesweep.sh
+++ b/benchmarks/cache/shapesweep.sh
@@ -20,13 +20,24 @@ SHAPES=(append-method remove-method edit-enum-case add-file remove-file rename-f
 
 cd "$APP" || exit 1
 
-if ! git diff --quiet; then
-  echo "ABORT: tracked files in cloud are modified"
-  exit 1
-fi
+# The shapes edit two tracked files. Both are copied first and restored from
+# those copies, so uncommitted work elsewhere in the app is left alone.
+MUTATED=(app/Models/Instance.php app/Enums/InstanceType.php)
+ORIGINALS=$S/sh-$LABEL-originals
+rm -rf "$ORIGINALS"; mkdir -p "$ORIGINALS"
+
+for file in "${MUTATED[@]}"; do
+  cp "$APP/$file" "$ORIGINALS/$(basename "$file")"
+done
+
+restore() {
+  for file in "${MUTATED[@]}"; do
+    cp "$ORIGINALS/$(basename "$file")" "$APP/$file"
+  done
+}
 
 cleanup() {
-  cd "$APP" && git checkout -- . 2>/dev/null
+  restore
   python3 "$S/mutate.py" cleanup apply
 }
 trap cleanup EXIT
@@ -46,7 +57,7 @@ mask() {
 printf '%-16s %14s %8s %s\n' shape warm-vs-cold raw effect
 
 for shape in "${SHAPES[@]}"; do
-  cd "$APP" && git checkout -- . 2>/dev/null
+  restore
   python3 "$S/mutate.py" cleanup apply
 
   python3 "$S/mutate.py" "$shape" pre

--- a/benchmarks/cache/surfacedump.php
+++ b/benchmarks/cache/surfacedump.php
@@ -1,0 +1,268 @@
+<?php
+
+/**
+ * Dumps a canonical view of every entry in a Surveyor analysis cache, so two
+ * runs can be compared without caring about object identity or key order.
+ *
+ * Usage: php surfacedump.php <cache-dir> [--detail]
+ *
+ * Without --detail: one `path<TAB>surface-hash<TAB>entry-hash` row per entry.
+ * With --detail: the canonical surface lines themselves, prefixed by path.
+ *
+ * The autoloader defaults to the Cloud checkout; override with SURFACE_AUTOLOAD.
+ */
+
+use Laravel\Surveyor\Analysis\Scope;
+use Laravel\Surveyor\Analyzed\ClassLikeResult;
+use Laravel\Surveyor\Analyzed\MethodResult;
+use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
+
+require getenv('SURFACE_AUTOLOAD') ?: '/Users/joetannenbaum/Herd/cloud/vendor/autoload.php';
+
+error_reporting(E_ALL & ~E_DEPRECATED);
+
+$dir = $argv[1] ?? exit("usage: surfacedump.php <cache-dir> [--detail]\n");
+$detail = in_array('--detail', $argv, true);
+
+// Hashes each top-level Scope property on its own, so a diff says which part
+// of an entry moved rather than only that it moved.
+$fields = in_array('--fields', $argv, true);
+
+function peek(object $object, string $property)
+{
+    $reflection = new ReflectionObject($object);
+
+    while ($reflection && ! $reflection->hasProperty($property)) {
+        $reflection = $reflection->getParentClass();
+    }
+
+    if (! $reflection) {
+        return null;
+    }
+
+    $prop = $reflection->getProperty($property);
+
+    return $prop->isInitialized($object) ? $prop->getValue($object) : null;
+}
+
+function typeId(?TypeContract $type): string
+{
+    if ($type === null) {
+        return '-';
+    }
+
+    try {
+        $id = $type->id();
+    } catch (Throwable $e) {
+        $id = 'ERR:'.$e->getMessage();
+    }
+
+    return $type::class.'('.$id.')'
+        .($type->isNullable() ? '|null' : '')
+        .($type->isOptional() ? '|opt' : '');
+}
+
+function methodLines(string $prefix, MethodResult $method): array
+{
+    $lines = [];
+
+    $parameters = [];
+
+    foreach (peek($method, 'parameters') ?? [] as $name => $type) {
+        $parameters[] = $name.':'.typeId($type);
+    }
+
+    $returns = [];
+
+    foreach (peek($method, 'returnTypes') ?? [] as $entry) {
+        $returns[] = typeId($entry['type']);
+    }
+
+    $lines[] = $prefix.' ('.implode(', ', $parameters).') -> '.implode(' + ', $returns)
+        .($method->isModelRelation() ? ' [relation]' : '');
+
+    foreach (peek($method, 'validationRules') ?? [] as $key => $rules) {
+        $lines[] = $prefix.' rule '.$key.' = '.json_encode($rules);
+    }
+
+    return $lines;
+}
+
+/**
+ * Everything a dependent can read off a cached entry, other than the state
+ * tracker, which holds the variables of the run that produced it.
+ */
+function scopeLines(Scope $scope): array
+{
+    $lines = [
+        'scope entity '.($scope->entityName() ?? '-'),
+        'scope method '.($scope->methodName() ?? '-'),
+        'scope namespace '.(peek($scope, 'namespace') ?? '-'),
+        'scope extends '.implode(',', peek($scope, 'extends') ?? []),
+        'scope implements '.implode(',', peek($scope, 'implements') ?? []),
+        'scope traits '.implode(',', peek($scope, 'traits') ?? []),
+    ];
+
+    foreach (peek($scope, 'uses') ?? [] as $alias => $use) {
+        $lines[] = 'scope use '.$alias.' = '.$use;
+    }
+
+    foreach (peek($scope, 'constants') ?? [] as $name => $type) {
+        $lines[] = 'scope constant '.$name.' '.(is_object($type) ? typeId($type) : json_encode($type));
+    }
+
+    foreach (peek($scope, 'cases') ?? [] as $name => $case) {
+        $lines[] = 'scope case '.$name.' '.(is_object($case) ? typeId($case) : json_encode($case));
+    }
+
+    foreach (peek($scope, 'parameters') ?? [] as $name => $type) {
+        $lines[] = 'scope parameter '.$name.' '.typeId($type);
+    }
+
+    foreach (peek($scope, 'returnTypes') ?? [] as $index => $type) {
+        $lines[] = 'scope return '.$index.' '.(is_object($type) ? typeId($type) : json_encode($type));
+    }
+
+    foreach (peek($scope, 'macros') ?? [] as $class => $macros) {
+        foreach ($macros as $name => $type) {
+            $lines[] = 'scope macro '.$class.'::'.$name.' '.typeId($type);
+        }
+    }
+
+    foreach (peek($scope, 'validationRules') ?? [] as $key => $rules) {
+        $lines[] = 'scope rule '.$key.' = '.json_encode($rules);
+    }
+
+    foreach (peek($scope, 'templateTags') ?? [] as $index => $tag) {
+        $lines[] = 'scope template '.$index.' '.(is_object($tag) && $tag instanceof TypeContract ? typeId($tag) : get_debug_type($tag));
+    }
+
+    $receiver = peek($scope, 'receiverType');
+
+    if ($receiver !== null) {
+        $lines[] = 'scope receiver '.typeId($receiver);
+    }
+
+    return $lines;
+}
+
+function fieldLines(Scope $scope): array
+{
+    $lines = [];
+
+    foreach ((new ReflectionObject($scope))->getProperties() as $property) {
+        if (! $property->isInitialized($scope)) {
+            $lines[] = 'field '.$property->getName().' <uninitialized>';
+
+            continue;
+        }
+
+        $value = $property->getValue($scope);
+
+        $lines[] = 'field '.$property->getName().' '.md5(serialize($value));
+    }
+
+    return $lines;
+}
+
+function surfaceLines(Scope $scope): array
+{
+    $result = $scope->result();
+
+    if ($result === null) {
+        return [...scopeLines($scope), '(no result)'];
+    }
+
+    if ($result instanceof MethodResult) {
+        return [...scopeLines($scope), ...methodLines('method '.$result->name(), $result)];
+    }
+
+    /** @var ClassLikeResult $result */
+    $lines = [
+        ...scopeLines($scope),
+        'class '.$result->name(),
+        'namespace '.(peek($result, 'namespace') ?? '-'),
+        'entity '.$result->entityType()->value,
+        'extends '.implode(',', $result->extends()),
+        'implements '.implode(',', $result->implements()),
+        'traits '.implode(',', peek($result, 'traits') ?? []),
+        'arrayable '.var_export($result->isArrayable(), true),
+    ];
+
+    foreach (peek($result, 'methods') ?? [] as $name => $method) {
+        $lines = [...$lines, ...methodLines('method '.$name, $method)];
+    }
+
+    foreach (peek($result, 'properties') ?? [] as $name => $property) {
+        $lines[] = 'property '.$name.' '.$property->visibility.' '.typeId($property->type)
+            .' doc='.var_export($property->fromDocBlock, true)
+            .' attr='.var_export($property->modelAttribute, true)
+            .' rel='.var_export($property->modelRelation, true)
+            .' ro='.var_export($property->readOnly, true)
+            .' wo='.var_export($property->writeOnly, true);
+    }
+
+    foreach (peek($result, 'constants') ?? [] as $name => $constant) {
+        $lines[] = 'constant '.$name.' '.typeId($constant->type);
+    }
+
+    sort($lines);
+
+    return $lines;
+}
+
+// Ranger keeps its structure index alongside the analysis entries.
+$files = array_values(array_filter(
+    glob(rtrim($dir, '/').'/*.cache'),
+    fn ($file) => ! str_starts_with(basename($file), 'inventory-'),
+));
+
+$rows = [];
+
+foreach ($files as $file) {
+    $content = file_get_contents($file);
+
+    // Entries may be HMAC prefixed; the signature is not part of the payload.
+    if (preg_match('/^[0-9a-f]{64}:/', $content)) {
+        $content = substr($content, 65);
+    }
+
+    try {
+        $data = unserialize($content);
+    } catch (Throwable $e) {
+        fwrite(STDERR, "unreadable: $file ({$e->getMessage()})\n");
+
+        continue;
+    }
+
+    if (! is_array($data) || ! ($data['scope'] ?? null) instanceof Scope) {
+        fwrite(STDERR, "unexpected payload: $file\n");
+
+        continue;
+    }
+
+    $scope = $data['scope'];
+    $path = peek($scope, 'path') ?? basename($file);
+    $lines = $fields ? fieldLines($scope) : surfaceLines($scope);
+
+    $rows[$path] = [
+        'surface' => md5(implode("\n", $lines)),
+        'entry' => md5(serialize($scope)),
+        'lines' => $lines,
+        'dependencies' => count($data['dependencies'] ?? []),
+    ];
+}
+
+ksort($rows);
+
+foreach ($rows as $path => $row) {
+    if ($detail) {
+        foreach ($row['lines'] as $line) {
+            echo $path, "\t", $line, "\n";
+        }
+
+        continue;
+    }
+
+    echo $path, "\t", $row['surface'], "\t", $row['entry'], "\t", $row['dependencies'], "\n";
+}

--- a/benchmarks/cache/timeit.sh
+++ b/benchmarks/cache/timeit.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Times cold, warm and warm-plus-edit for a given Surveyor source tree.
+#
+# Usage: timeit.sh <label> [src-dir] [repeats] [target]
+#
+# Copies <src-dir> into the app's vendor directory, then for each repeat builds
+# from an empty cache, builds again with nothing changed, and builds once more
+# after appending a method to one model. The edited file is restored from a copy
+# rather than through git, so uncommitted work in the app survives.
+
+set -u
+
+S="$(cd "$(dirname "$0")" && pwd)"
+APP=/Users/joetannenbaum/Herd/cloud
+LABEL=$1
+SRC=${2:-/Users/joetannenbaum/Dev/surveyor/src}
+RUNS=${3:-2}
+TARGET=$APP/${4:-app/Models/Instance.php}
+BACKUP=$S/tm-$LABEL-$(basename "${4:-Instance.php}").orig
+
+rsync -a --delete "$SRC/" "$APP/vendor/laravel/surveyor/src/"
+cp "$TARGET" "$BACKUP"
+trap 'cp "$BACKUP" "$TARGET"' EXIT
+
+cd "$APP" || exit 1
+
+time_run() {
+  local cache=$1 out=$2 start end
+  rm -rf "$out"; mkdir -p "$out"
+  start=$(php -r 'echo microtime(true);')
+  WAYFINDER_CACHE_DIRECTORY=$cache php artisan wayfinder:generate --path="$out" > /dev/null 2>&1
+  end=$(php -r 'echo microtime(true);')
+  php -r "printf('%.2f', $end - $start);"
+}
+
+printf '%-14s %3s %7s %7s %7s %8s %6s %10s\n' label run cold warm edit entries mb rewritten
+
+for i in $(seq 1 "$RUNS"); do
+  CACHE=$S/tm-$LABEL-cache
+  rm -rf "$CACHE"; mkdir -p "$CACHE"
+
+  cold=$(time_run "$CACHE" "$S/tm-out")
+  entries=$(find "$CACHE" -name '*.cache' | wc -l | tr -d ' ')
+  size=$(du -sm "$CACHE" | cut -f1 | tr -d ' ')
+
+  warm=$(time_run "$CACHE" "$S/tm-out")
+
+  before=$(mktemp)
+  find "$CACHE" -name '*.cache' -exec stat -f '%N %m' {} \; | sort > "$before"
+
+  sleep 1
+  python3 - "$TARGET" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+i = s.rstrip().rfind('\n}')
+probe = "\n    public function benchProbeRelation(): HasOne\n    {\n        return $this->hasOne(Daemon::class);\n    }\n"
+open(p, 'w').write(s[:i] + probe + s[i:])
+PY
+
+  edit=$(time_run "$CACHE" "$S/tm-out")
+
+  after=$(mktemp)
+  find "$CACHE" -name '*.cache' -exec stat -f '%N %m' {} \; | sort > "$after"
+  rewritten=$(comm -13 "$before" "$after" | wc -l | tr -d ' ')
+
+  cp "$BACKUP" "$TARGET"
+  rm -f "$before" "$after"
+
+  printf '%-14s %3s %7s %7s %7s %8s %6s %10s\n' "$LABEL" "$i" "$cold" "$warm" "$edit" "$entries" "$size" "$rewritten"
+done

--- a/src/Analyzer/AnalyzedCache.php
+++ b/src/Analyzer/AnalyzedCache.php
@@ -46,6 +46,14 @@ class AnalyzedCache
     protected static array $deferred = [];
 
     /**
+     * Members of cycles that have just closed. Each was analyzed while another
+     * member was still open, so it resolved part of its work against nothing.
+     *
+     * @var list<string>
+     */
+    protected static array $settled = [];
+
+    /**
      * Every file each analyzed path depends on, directly or otherwise. Stored
      * as a closure rather than direct edges so a cache entry can be validated
      * by stat'ing a flat list, without walking the graph.
@@ -180,11 +188,26 @@ class AnalyzedCache
             unset($own[$entry['path']]);
 
             static::$dependencies[$entry['path']] = $own;
+            static::$settled[] = $entry['path'];
 
             if (static::$persistToDisk) {
                 static::persistToDisk($entry['path'], $entry['scope'], $entry['mtime'], $own);
             }
         }
+    }
+
+    /**
+     * Hand back the members of any cycle that has closed since this was last
+     * called, and forget them.
+     *
+     * @return list<string>
+     */
+    public static function takeSettled(): array
+    {
+        $settled = static::$settled;
+        static::$settled = [];
+
+        return $settled;
     }
 
     /**
@@ -422,6 +445,7 @@ class AnalyzedCache
         static::$frameTainted = [];
         static::$cycleFloor = null;
         static::$deferred = [];
+        static::$settled = [];
         static::$modifiedTimes = [];
     }
 

--- a/src/Analyzer/Analyzer.php
+++ b/src/Analyzer/Analyzer.php
@@ -13,6 +13,8 @@ class Analyzer
 
     protected int $analyzing = 0;
 
+    protected bool $settling = false;
+
     public function __construct(
         protected Parser $parser,
     ) {
@@ -84,11 +86,59 @@ class Analyzer
             AnalyzedCache::endAnalysis($path);
         }
 
+        $this->settle();
+
         Debug::removePath($path);
 
         $this->analyzing--;
 
         return $this;
+    }
+
+    /**
+     * Analyze the members of a cycle again now that it has closed.
+     *
+     * Each of them ran while another member was still open, so wherever they
+     * reached for it they resolved against an empty scope. Which member that
+     * was depends on where the analysis happened to start, so leaving those
+     * answers in place makes the cache depend on visit order. One member is
+     * re-analyzed at a time, with the rest left in the cache, so each of them
+     * sees a finished answer for everything it reaches.
+     */
+    protected function settle(): void
+    {
+        if ($this->settling) {
+            return;
+        }
+
+        $members = AnalyzedCache::takeSettled();
+
+        if ($members === []) {
+            return;
+        }
+
+        $mine = $this->analyzed ?? null;
+        $this->settling = true;
+
+        try {
+            foreach ($members as $member) {
+                AnalyzedCache::invalidate($member);
+
+                Debug::log(static fn () => '♻️ Re-analyzing settled cycle member: '.self::shortPath($member));
+
+                $this->analyze($member);
+            }
+        } finally {
+            $this->settling = false;
+
+            // Anything a member reached while settling has been analyzed with
+            // the cycle closed, so there is nothing left to settle.
+            AnalyzedCache::takeSettled();
+
+            if ($mine !== null) {
+                $this->analyzed = $mine;
+            }
+        }
     }
 
     protected static function shortPath(string $path): string

--- a/src/NodeResolvers/Shared/ResolvesMethodCalls.php
+++ b/src/NodeResolvers/Shared/ResolvesMethodCalls.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Request as RequestFacade;
 use Laravel\Surveyor\Concerns\LazilyLoadsDependencies;
 use Laravel\Surveyor\Types\ClassType;
+use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 use Laravel\Surveyor\Types\MixedType;
 use Laravel\Surveyor\Types\StringType;
 use Laravel\Surveyor\Types\Type;
@@ -60,12 +61,35 @@ trait ResolvesMethodCalls
             return $this->resolveResourceConditional($var, $methodName->value, $node);
         }
 
-        return Type::union(
+        $returned = Type::union(
             ...$this->reflector->methodReturnType(
                 $var,
                 $methodName->value,
                 $node,
             ),
         );
+
+        return $this->keepReceiver($var, $returned);
+    }
+
+    /**
+     * A fluent method hands back the object it was called on. Reflection only
+     * reports which class that is, so a receiver carrying more than a class
+     * name, such as a resource response and the shape it produces, would come
+     * back as a bare class and lose the shape.
+     */
+    protected function keepReceiver(ClassType $var, TypeContract $returned): TypeContract
+    {
+        if ($var::class === ClassType::class || $returned::class !== ClassType::class) {
+            return $returned;
+        }
+
+        if ($returned->resolved() !== $var->resolved()) {
+            return $returned;
+        }
+
+        return $returned->isNullable() && ! $var->isNullable()
+            ? (clone $var)->nullable()
+            : $var;
     }
 }

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -22,11 +22,8 @@ class Parser
         protected NodeResolver $resolver,
         protected PhpParserParser $parser,
         protected NodeFinder $nodeFinder,
-        protected NodeTraverser $nodeTraverser,
-        protected TypeResolver $typeResolver,
     ) {
-        $this->nodeTraverser->addVisitor(new NameResolver(null, ['preserveOriginalNames' => true]));
-        $this->nodeTraverser->addVisitor($this->typeResolver);
+        //
     }
 
     /**
@@ -36,9 +33,7 @@ class Parser
         string|ReflectionClass|ReflectionFunction|ReflectionMethod|SplFileInfo $code,
         string $path,
     ): array {
-        $this->parseCode($code, $path);
-
-        return [$this->flipScope($this->typeResolver->scope())];
+        return [$this->flipScope($this->parseCode($code, $path))];
     }
 
     protected function flipScope(Scope $scope)
@@ -55,19 +50,33 @@ class Parser
         return $this->parser->parse(file_get_contents($path));
     }
 
+    /**
+     * Resolving a node can analyze another file, which lands back here while
+     * this traversal is still running. The traverser and both visitors carry
+     * the state of the file they are walking, so each parse gets its own set
+     * rather than having the nested file overwrite the outer file's imports
+     * halfway through.
+     */
     protected function parseCode(
         string|ReflectionClass|ReflectionFunction|ReflectionMethod|SplFileInfo $code,
         string $path,
-    ): array {
+    ): Scope {
         $code = match (true) {
             is_string($code) => $code,
             $code instanceof SplFileInfo => file_get_contents($code->getPathname()),
             default => file_get_contents($code->getFileName()),
         };
 
-        $this->typeResolver->newScope($path);
+        $typeResolver = new TypeResolver($this->resolver);
+        $typeResolver->newScope($path);
 
-        return $this->nodeTraverser->traverse($this->parser->parse($code));
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor(new NameResolver(null, ['preserveOriginalNames' => true]));
+        $traverser->addVisitor($typeResolver);
+
+        $traverser->traverse($this->parser->parse($code));
+
+        return $typeResolver->scope();
     }
 
     public function nodeFinder()

--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -309,15 +309,18 @@ class Reflector
         $className = $class instanceof ClassType ? $class->value : $class;
         $reflection = $this->reflectClass($class);
 
+        $scopeToRestore = null;
+
+        // Looking at another class means resolving names against that class's
+        // imports, so the scope in hand is put back before returning.
         if ($this->scope->entityName() !== $reflection->getName()) {
             $analyzed = $this->getAnalyzer()->analyze($reflection->getFileName());
 
             if ($scope = $analyzed->analyzed()) {
+                $scopeToRestore = $this->scope;
                 $this->setScope($scope);
             }
         }
-
-        $scopeToRestore = null;
 
         if ($class instanceof ClassType && count($class->genericTypes()) > 0) {
             $templateTags = $this->scope->getTemplateTags();
@@ -337,7 +340,7 @@ class Reflector
                     $templateTags,
                 );
 
-                $scopeToRestore = $this->scope;
+                $scopeToRestore ??= $this->scope;
                 $tempScope = clone $this->scope;
                 $tempScope->setTemplateTags(array_values($overriddenTags));
                 $tempScope->setReceiverType($class);

--- a/tests/Unit/Analyzer/DeterminismTest.php
+++ b/tests/Unit/Analyzer/DeterminismTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use Laravel\Surveyor\Analysis\Scope;
+use Laravel\Surveyor\Analyzer\AnalyzedCache;
+use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
+
+uses()->group('integration');
+
+beforeEach(function () {
+    AnalyzedCache::clear();
+
+    app()->forgetInstance(Analyzer::class);
+});
+
+afterEach(function () {
+    AnalyzedCache::clear();
+});
+
+function determinismFixture(string $name): string
+{
+    return dirname(__DIR__, 3).'/workbench/app/Determinism/'.$name;
+}
+
+/**
+ * The part of an analyzed file a dependent can observe: its methods, their
+ * parameters and what they return.
+ */
+function surfaceOf(?Scope $scope): array
+{
+    $result = $scope?->result();
+
+    if ($result === null) {
+        return [];
+    }
+
+    $describe = fn (?TypeContract $type) => $type === null
+        ? '-'
+        : $type::class.':'.$type->id().($type->isNullable() ? '|null' : '');
+
+    $lines = [];
+
+    foreach ($result->publicMethods() as $name => $method) {
+        $parameters = [];
+
+        foreach ($method->parameters() as $parameter => $type) {
+            $parameters[] = $parameter.' '.$describe($type);
+        }
+
+        $lines[] = $name.'('.implode(', ', $parameters).'): '.$describe($method->returnType());
+    }
+
+    sort($lines);
+
+    return $lines;
+}
+
+it('resolves a file\'s own imports after analyzing another file', function () {
+    $analyzed = app(Analyzer::class)->analyze(determinismFixture('Outer.php'));
+
+    $stamp = $analyzed->result()->getMethod('stamp');
+
+    expect($stamp->parameters()['marker']->id())->toBe('App\\Determinism\\Types\\Marker');
+    expect($stamp->returnType()->id())->toBe('App\\Determinism\\Types\\Marker');
+});
+
+it('gives the same surface whichever file is analyzed first', function () {
+    $analyzer = app(Analyzer::class);
+
+    $first = surfaceOf($analyzer->analyze(determinismFixture('Outer.php'))->analyzed());
+
+    expect($first)->not->toBeEmpty();
+
+    AnalyzedCache::clear();
+    app()->forgetInstance(Analyzer::class);
+
+    $analyzer = app(Analyzer::class);
+    $analyzer->analyze(determinismFixture('Nested.php'));
+
+    $second = surfaceOf($analyzer->analyze(determinismFixture('Outer.php'))->analyzed());
+
+    expect($second)->toBe($first);
+});
+
+it('settles a cycle member against the finished analysis of the other member', function () {
+    $analyzer = app(Analyzer::class);
+
+    // Alpha is analyzed from inside Beta, so it asks what Beta::make() returns
+    // while Beta is still open.
+    $analyzer->analyze(determinismFixture('Cycle/Beta.php'));
+
+    $alpha = $analyzer->analyze(determinismFixture('Cycle/Alpha.php'))->result();
+
+    expect($alpha->getMethod('beta')->returnType()->id())->toBe('App\\Determinism\\Cycle\\Beta');
+});

--- a/workbench/app/Determinism/Cycle/Alpha.php
+++ b/workbench/app/Determinism/Cycle/Alpha.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Determinism\Cycle;
+
+class Alpha
+{
+    public function label(): string
+    {
+        return 'alpha';
+    }
+
+    /**
+     * Nothing here says what this returns. Answering means knowing what
+     * `static` means inside Beta, which is only knowable once Beta's own
+     * analysis has finished.
+     */
+    public function beta()
+    {
+        return Beta::make();
+    }
+}

--- a/workbench/app/Determinism/Cycle/Beta.php
+++ b/workbench/app/Determinism/Cycle/Beta.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Determinism\Cycle;
+
+class Beta
+{
+    public static function make(): static
+    {
+        return new static;
+    }
+
+    /**
+     * Calling into Alpha analyzes it while this file is still open, which is
+     * what puts Alpha in a cycle with this one.
+     */
+    public function touch(): string
+    {
+        return (new Alpha)->label();
+    }
+}

--- a/workbench/app/Determinism/Marker.php
+++ b/workbench/app/Determinism/Marker.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Determinism;
+
+/**
+ * Only here to be the wrong answer. See App\Determinism\Types\Marker.
+ */
+class Marker
+{
+    //
+}

--- a/workbench/app/Determinism/Nested.php
+++ b/workbench/app/Determinism/Nested.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Determinism;
+
+class Nested
+{
+    public function name(): string
+    {
+        return 'nested';
+    }
+}

--- a/workbench/app/Determinism/Outer.php
+++ b/workbench/app/Determinism/Outer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Determinism;
+
+use App\Determinism\Types\Marker;
+
+class Outer
+{
+    /**
+     * Calling into another class makes the analyzer stop and analyze that
+     * file, so the method below is reached with another file's analysis
+     * already finished.
+     */
+    public function boot(): string
+    {
+        return (new Nested)->name();
+    }
+
+    public function stamp(?Marker $marker): ?Marker
+    {
+        return $marker;
+    }
+}

--- a/workbench/app/Determinism/Types/Marker.php
+++ b/workbench/app/Determinism/Types/Marker.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Determinism\Types;
+
+/**
+ * The class Outer imports. A run that loses Outer's imports halfway through
+ * resolves the name against Outer's own namespace instead and lands on
+ * App\Determinism\Marker, which is why that class exists too.
+ */
+class Marker
+{
+    //
+}


### PR DESCRIPTION
Analysing the same file twice could give two different answers, depending on which file the run started from. `Parser` kept one traverser and its visitors for a whole run, so when resolving a node stopped to analyse another file, that file's imports replaced the outer file's for the rest of the traversal, and short class names then resolved to the wrong class. Each parse now gets its own traverser and visitors.

Cycles were the other source. When two files need each other, one of them resolves against an empty scope and records mixed, and which one depends on where the run began. Members of a cycle are now analysed again once it closes, one at a time with the others left in the cache.

Two smaller fixes fell out of it. A fluent call such as `Resource::make($x)->forParent($y)` lost the resource and came back as a bare class, so generated types referred to types that were never declared; a call whose return type is its receiver's own class now hands the receiver back. That gives 15 declarations a real shape and clears three dangling references. And `Reflector::methodReturnType` no longer leaves the shared reflector pointed at the last class it looked at.

Also adds a harness under `benchmarks/cache` for measuring any of this again: `determinism.sh`, `surfacedump.php` and `timeit.sh`.
