### PR TITLE
Recognize ignore markers during analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ if ($classResult->implements(JsonSerializable::class)) {
 
 Access information about class methods:
 
+A method marked to be left out is hidden from every one of these, so `hasMethod()` returns false for it and `getMethod()` returns null. See [Ignore Markers](#ignore-markers).
+
 ```php
 // Check if a method exists
 if ($classResult->hasMethod('store')) {
@@ -119,11 +121,16 @@ if ($classResult->hasMethod('store')) {
 
 // Get all public methods
 $publicMethods = $classResult->publicMethods();
+
+// Read a method past the marker filter, to inspect a marker rather than act on it
+$raw = $classResult->method('store');
 ```
 
 ### Properties
 
 Access information about class properties:
+
+As with methods, a property marked to be left out is hidden from these, and `getProperty()` returns null for it.
 
 ```php
 // Check if a property exists
@@ -137,6 +144,9 @@ if ($classResult->hasProperty('email')) {
 
 // Get all public properties
 $publicProperties = $classResult->publicProperties();
+
+// Read a property past the marker filter
+$raw = $classResult->property('email');
 ```
 
 ### Constants
@@ -148,6 +158,100 @@ if ($classResult->hasConstant('STATUS_ACTIVE')) {
     $constant = $classResult->getConstant('STATUS_ACTIVE');
 }
 ```
+
+## Ignore Markers
+
+A tool that turns an application into client-side code needs a way for the author of that application to say "leave this one out". Surveyor recognizes the marker and hides what it covers; it does not decide what the marker is called, so each consumer ships an attribute in its own vocabulary.
+
+An attribute class is a marker if it implements `Laravel\Surveyor\Contracts\Ignored`. Nothing needs registering:
+
+```php
+use Attribute;
+use Laravel\Surveyor\Contracts\Ignored;
+
+#[Attribute(Attribute::TARGET_ALL)]
+final class Ignore implements Ignored
+{
+    //
+}
+```
+
+Marked members are hidden wherever a result hands members out: `publicMethods()`, `publicProperties()`, `hasMethod()`, `getMethod()`, `hasProperty()`, `getProperty()`, `asArray()`, and `asJson()`. A marked class, interface, or method is reported by `isIgnored()`. To read a member past the filter, ask for it by name through `method()` or `property()`.
+
+### Conditions
+
+A marker can apply only some of the time. Implement `ConditionallyIgnored` and the two conditions are read from the attribute as written:
+
+```php
+use Laravel\Surveyor\Contracts\ConditionallyIgnored;
+
+#[Attribute(Attribute::TARGET_ALL)]
+final class Ignore implements ConditionallyIgnored
+{
+    public function __construct(
+        public readonly string|array|null $unless = null,
+        public readonly string|array|null $when = null,
+    ) {
+    }
+
+    public function unless(): string|array|null
+    {
+        return $this->unless;
+    }
+
+    public function when(): string|array|null
+    {
+        return $this->when;
+    }
+}
+```
+
+`unless` keeps the declaration while its condition passes; `when` leaves it out while its condition passes. A condition is a config key or a `[class, method]` callable — nothing else counts as one, so a marker given anything else still hides. Surveyor does not decide what a condition means, so register a resolver:
+
+```php
+use Laravel\Surveyor\Support\Markers;
+
+Markers::registerConditionResolver(fn (string|array $condition) => is_string($condition)
+    ? (bool) config($condition, false)
+    : (bool) app()->call($condition));
+```
+
+Register the resolver before reading results. Until one is registered nothing can answer a condition, and an unanswerable condition is not a failing one: every conditional marker hides, the same as one whose condition could not be read.
+
+Conditions are resolved when a member is read, not while the file is analyzed, so a cached analysis holds the condition and never the answer to it. A condition that cannot be read at all — an expression surveyor cannot evaluate — leaves the declaration out whichever argument carried it.
+
+Only a marker implementing `ConditionallyIgnored` carries conditions. An argument on any other marker is left alone, so an attribute that is unconditional by contract cannot be switched off by one. Name the constructor parameters `unless` and `when`. A positional argument is matched against the marker's own constructor parameters, but both readers then look for those two names: reading an attribute out of a file goes by the parameter name, while instantiating it goes through the contract methods. Parameters named anything else are not seen by the file reader, which leaves the marker unconditional there while instantiating it honors the condition.
+
+### Comment Tags
+
+An array key cannot carry an attribute, so register a comment tag instead:
+
+```php
+Markers::registerTags('ignore');
+```
+
+The tag can sit above the key or at the end of its line, and keys are matched by position rather than by what the parser attached the comment to:
+
+```php
+return [
+    'name' => $this->name,
+    'ssn' => $this->ssn, // @ignore
+    // @ignore
+    'token' => $this->token,
+];
+```
+
+A tag in a doc block also marks the declaration it belongs to. No tag is honored until it is registered.
+
+### Markers You Cannot Change
+
+To treat an attribute from another package as a marker, register it by name:
+
+```php
+Markers::registerAttributes(\Vendor\Package\Attributes\Internal::class);
+```
+
+Markers on declarations reached through reflection rather than through the file — a member from a trait or a parent class — are read with `Markers::fromReflection($reflection)`, which returns an `IgnoreMarker` or null.
 
 ## Type System
 

--- a/src/Analysis/Scope.php
+++ b/src/Analysis/Scope.php
@@ -64,6 +64,9 @@ class Scope
 
     protected ?ClassType $receiverType = null;
 
+    /** @var list<array{pos: int, line: int}>|null */
+    protected ?array $ignoreMarkerComments = null;
+
     public function __construct(protected ?Scope $parent = null)
     {
         $this->stateTracker = new StateTracker;
@@ -161,6 +164,22 @@ class Scope
         }
 
         return $this->path;
+    }
+
+    /**
+     * @param  list<array{pos: int, line: int}>  $comments
+     */
+    public function setIgnoreMarkerComments(array $comments): void
+    {
+        $this->ignoreMarkerComments = $comments;
+    }
+
+    /**
+     * @return list<array{pos: int, line: int}>
+     */
+    public function ignoreMarkerComments(): array
+    {
+        return $this->ignoreMarkerComments ?? $this->parent?->ignoreMarkerComments() ?? [];
     }
 
     public function path(): ?string

--- a/src/Analyzed/ClassLikeResult.php
+++ b/src/Analyzed/ClassLikeResult.php
@@ -5,10 +5,13 @@ namespace Laravel\Surveyor\Analyzed;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 use Laravel\Surveyor\Analysis\EntityType;
+use Laravel\Surveyor\Concerns\HasIgnoreMarker;
 use Laravel\Surveyor\Types\Type;
 
 class ClassLikeResult
 {
+    use HasIgnoreMarker;
+
     /** @var array<string, PropertyResult> */
     protected array $properties = [];
 
@@ -107,6 +110,10 @@ class ClassLikeResult
                 $method->flagAsModelRelation();
             }
 
+            if ($existing->ignoreMarker() !== null) {
+                $method->flagAsIgnored($existing->ignoreMarker());
+            }
+
             $existingTypes = array_column($existing->returnTypes(), 'type');
             $newTypes = array_column($method->returnTypes(), 'type');
             $mergedType = Type::union(...$existingTypes, ...$newTypes);
@@ -135,32 +142,55 @@ class ClassLikeResult
         return count(array_intersect($implements, $this->implements)) > 0;
     }
 
+    /**
+     * Every way of reading a member out of a result hides the ones marked to be
+     * left out: looking one up by name as much as listing them. A caller that
+     * needs to see past that, to read a marker rather than act on one, asks for
+     * it by name through method() or property().
+     */
     public function hasMethod(string $name): bool
     {
-        return isset($this->methods[$name]);
+        return $this->getMethod($name) !== null;
     }
 
-    public function getMethod(string $name): MethodResult
+    public function getMethod(string $name): ?MethodResult
     {
-        return $this->methods[$name];
+        $method = $this->method($name);
+
+        return $method === null || $method->isIgnored() ? null : $method;
+    }
+
+    public function method(string $name): ?MethodResult
+    {
+        return $this->methods[$name] ?? null;
     }
 
     public function hasProperty(string $name): bool
     {
-        return isset($this->properties[$name]);
+        return $this->getProperty($name) !== null;
     }
 
-    public function getProperty(string $name): PropertyResult
+    public function getProperty(string $name): ?PropertyResult
     {
-        return $this->properties[$name];
+        $property = $this->property($name);
+
+        return $property === null || $property->isIgnored() ? null : $property;
+    }
+
+    public function property(string $name): ?PropertyResult
+    {
+        return $this->properties[$name] ?? null;
     }
 
     /**
-     * @return list<MethodResult>
+     * @return array<string, MethodResult>
      */
     public function publicMethods(): array
     {
-        return $this->methods;
+        return array_filter(
+            $this->methods,
+            fn (MethodResult $method) => ! $method->isIgnored(),
+        );
     }
 
     /**
@@ -171,7 +201,7 @@ class ClassLikeResult
         return array_values(
             array_filter(
                 $this->properties,
-                fn (PropertyResult $property) => $property->visibility === 'public',
+                fn (PropertyResult $property) => $property->visibility === 'public' && ! $property->isIgnored(),
             ),
         );
     }

--- a/src/Analyzed/IgnoreMarker.php
+++ b/src/Analyzed/IgnoreMarker.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Laravel\Surveyor\Analyzed;
+
+use Laravel\Surveyor\Support\Markers;
+
+final class IgnoreMarker
+{
+    /**
+     * Declared rather than promoted so that unserializing a marker written by
+     * an older version of this class falls back to the defaults instead of
+     * leaving a typed property uninitialized.
+     */
+    public string|array|null $unless = null;
+
+    public string|array|null $when = null;
+
+    public function __construct(
+        string|array|null $unless = null,
+        string|array|null $when = null,
+    ) {
+        $this->unless = self::condition($unless);
+        $this->when = self::condition($when);
+    }
+
+    /**
+     * Whether the marker hides its declaration right now.
+     *
+     * A marker with no condition always hides. Otherwise each condition can
+     * only add hiding, never take it away, so combining the two is safe and
+     * anything that is not a condition at all leaves nothing behind: it lands
+     * here as no condition, which hides. Over-hiding shows up as a type error,
+     * while under-hiding ships the thing the marker was put there to hold back.
+     */
+    public function hides(): bool
+    {
+        if ($this->unless === null && $this->when === null) {
+            return true;
+        }
+
+        // A condition nothing can answer is not a condition that failed. With
+        // no resolver registered there is no way to tell whether it holds, so
+        // this lands with the unreadable ones and hides.
+        if (! Markers::canResolveConditions()) {
+            return true;
+        }
+
+        if ($this->when !== null && Markers::conditionPasses($this->when)) {
+            return true;
+        }
+
+        return $this->unless !== null && ! Markers::conditionPasses($this->unless);
+    }
+
+    /**
+     * A condition is a config key or a [class, method] callable. Anything else
+     * is not a condition, whatever it was written as.
+     */
+    protected static function condition(string|array|null $condition): string|array|null
+    {
+        if (is_string($condition)) {
+            return $condition === '' ? null : $condition;
+        }
+
+        if (! is_array($condition) || count($condition) !== 2 || ! array_is_list($condition)) {
+            return null;
+        }
+
+        [$class, $method] = $condition;
+
+        return is_string($class) && is_string($method) ? $condition : null;
+    }
+}

--- a/src/Analyzed/MethodResult.php
+++ b/src/Analyzed/MethodResult.php
@@ -2,11 +2,14 @@
 
 namespace Laravel\Surveyor\Analyzed;
 
+use Laravel\Surveyor\Concerns\HasIgnoreMarker;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 use Laravel\Surveyor\Types\Type;
 
 class MethodResult
 {
+    use HasIgnoreMarker;
+
     /** @var array<string, TypeContract> */
     protected array $parameters = [];
 

--- a/src/Analyzed/PropertyResult.php
+++ b/src/Analyzed/PropertyResult.php
@@ -2,10 +2,13 @@
 
 namespace Laravel\Surveyor\Analyzed;
 
+use Laravel\Surveyor\Concerns\HasIgnoreMarker;
 use Laravel\Surveyor\Types\Contracts\Type;
 
 class PropertyResult
 {
+    use HasIgnoreMarker;
+
     public function __construct(
         public readonly string $name,
         public readonly ?Type $type,
@@ -15,7 +18,8 @@ class PropertyResult
         public readonly bool $modelRelation = false,
         public readonly bool $readOnly = false,
         public readonly bool $writeOnly = false,
+        ?IgnoreMarker $ignore = null,
     ) {
-        //
+        $this->ignore = $ignore;
     }
 }

--- a/src/Analyzer/AnalyzedCache.php
+++ b/src/Analyzer/AnalyzedCache.php
@@ -10,6 +10,13 @@ use function Illuminate\Filesystem\join_paths;
 
 class AnalyzedCache
 {
+    /**
+     * The shape of what gets written to disk. Bump it whenever a serialized
+     * class changes, so an upgrade reads its own entries and not ones left by
+     * a version whose objects no longer unserialize cleanly.
+     */
+    public const SCHEMA = 4;
+
     protected static array $cached = [];
 
     protected static array $fileTimes = [];
@@ -340,6 +347,12 @@ class AnalyzedCache
             return null;
         }
 
+        if (($data['schema'] ?? null) !== static::SCHEMA) {
+            static::invalidate($path);
+
+            return null;
+        }
+
         if ($data['mtime'] !== $currentModifiedTime) {
             static::invalidate($path);
 
@@ -478,6 +491,7 @@ class AnalyzedCache
         $cacheFile = static::getCacheFilePath($path);
 
         $data = [
+            'schema' => static::SCHEMA,
             'mtime' => $mtime,
             'dependencies' => array_values(array_filter(array_map(fn ($dep) => [
                 'path' => $dep,

--- a/src/Analyzer/ModelAnalyzer.php
+++ b/src/Analyzer/ModelAnalyzer.php
@@ -6,14 +6,19 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\ModelInspector;
+use Illuminate\Support\Str;
 use Laravel\Surveyor\Analysis\Scope;
 use Laravel\Surveyor\Analyzed\ClassLikeResult;
+use Laravel\Surveyor\Analyzed\IgnoreMarker;
 use Laravel\Surveyor\Analyzed\MethodResult;
 use Laravel\Surveyor\Analyzed\PropertyResult;
 use Laravel\Surveyor\Reflector\Reflector;
+use Laravel\Surveyor\Support\Markers;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 use Laravel\Surveyor\Types\Type;
+use ReflectionClass;
+use Throwable;
 
 class ModelAnalyzer
 {
@@ -46,7 +51,12 @@ class ModelAnalyzer
                 }
             }
 
-            $result->addProperty(new PropertyResult($attribute['name'], $type, modelAttribute: true));
+            $result->addProperty(new PropertyResult(
+                $attribute['name'],
+                $type,
+                modelAttribute: true,
+                ignore: $this->inheritedMarker($model, $result, $attribute['name']),
+            ));
             $scope->state()->properties()->addManually($attribute['name'], $type, 0, 0, 0, 0);
         }
 
@@ -61,13 +71,23 @@ class ModelAnalyzer
 
             if ($isCollection) {
                 $type = Type::arrayShape(Type::int(), new ClassType($relation['related']));
-                $result->addProperty(new PropertyResult($relation['name'], $type, modelRelation: true));
+                $result->addProperty(new PropertyResult(
+                    $relation['name'],
+                    $type,
+                    modelRelation: true,
+                    ignore: $this->inheritedMarker($model, $result, $relation['name']),
+                ));
                 $scope->state()->properties()->addManually($relation['name'], $type, 0, 0, 0, 0);
             } else {
                 // A singular relation has nothing to return when the related
                 // record is missing, whatever the foreign key says.
                 $type = (new ClassType($relation['related']))->nullable();
-                $result->addProperty(new PropertyResult($relation['name'], $type, modelRelation: true));
+                $result->addProperty(new PropertyResult(
+                    $relation['name'],
+                    $type,
+                    modelRelation: true,
+                    ignore: $this->inheritedMarker($model, $result, $relation['name']),
+                ));
                 $scope->state()->properties()->addManually($relation['name'], $type, 0, 0, 0, 0);
             }
 
@@ -85,6 +105,59 @@ class ModelAnalyzer
 
             $result->addMethod($methodResult);
         }
+    }
+
+    /**
+     * Attributes and relations are named by the model inspector, not by the
+     * file, so a marker put on the accessor or the relation method has to be
+     * carried across to the member it produces.
+     */
+    protected function inheritedMarker(string $model, ClassLikeResult $result, string $name): ?IgnoreMarker
+    {
+        if ($result->property($name)?->ignoreMarker() !== null) {
+            return $result->property($name)->ignoreMarker();
+        }
+
+        $methods = [
+            $name,
+            Str::camel($name),
+            'get'.Str::studly($name).'Attribute',
+        ];
+
+        foreach ($methods as $method) {
+            if ($result->method($method)?->ignoreMarker() !== null) {
+                return $result->method($method)->ignoreMarker();
+            }
+        }
+
+        return $this->reflectedMarker($model, $name, $methods);
+    }
+
+    /**
+     * The analyzed result only holds what the model's own file declares, so a
+     * marker on a member reached through a trait or a parent class is only
+     * visible through reflection.
+     *
+     * @param  list<string>  $methods
+     */
+    protected function reflectedMarker(string $model, string $name, array $methods): ?IgnoreMarker
+    {
+        try {
+            $reflection = new ReflectionClass($model);
+        } catch (Throwable) {
+            return null;
+        }
+
+        foreach ($methods as $method) {
+            if ($reflection->hasMethod($method)
+                && $marker = Markers::fromReflection($reflection->getMethod($method))) {
+                return $marker;
+            }
+        }
+
+        return $reflection->hasProperty($name)
+            ? Markers::fromReflection($reflection->getProperty($name))
+            : null;
     }
 
     protected function annotatedType(ClassLikeResult $result, string $name): ?TypeContract
@@ -224,11 +297,11 @@ class ModelAnalyzer
             return Type::string($cast);
         }
 
-        if ($analyzed->implements(CastsAttributes::class)) {
+        if ($analyzed->implements(CastsAttributes::class) && $analyzed->hasMethod('get')) {
             return $analyzed->getMethod('get')->returnType();
         }
 
-        if ($analyzed->implements(Arrayable::class)) {
+        if ($analyzed->implements(Arrayable::class) && $analyzed->hasMethod('toArray')) {
             return $analyzed->getMethod('toArray')->returnType();
         }
 

--- a/src/Concerns/HasIgnoreMarker.php
+++ b/src/Concerns/HasIgnoreMarker.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Laravel\Surveyor\Concerns;
+
+use Laravel\Surveyor\Analyzed\IgnoreMarker;
+
+trait HasIgnoreMarker
+{
+    /**
+     * Declared rather than promoted by the classes using this, so that
+     * unserializing a result written before the marker existed falls back to
+     * the default instead of leaving a typed property uninitialized.
+     */
+    protected ?IgnoreMarker $ignore = null;
+
+    public function flagAsIgnored(?IgnoreMarker $marker = null): void
+    {
+        $this->ignore = $marker ?? new IgnoreMarker;
+    }
+
+    public function ignoreMarker(): ?IgnoreMarker
+    {
+        return $this->ignore;
+    }
+
+    /**
+     * Whether this should be left out as things stand. A marker carrying a
+     * condition is answered here, when it is read, rather than when the file it
+     * came from was analyzed.
+     */
+    public function isIgnored(): bool
+    {
+        return $this->ignore?->hides() ?? false;
+    }
+}

--- a/src/Contracts/ConditionallyIgnored.php
+++ b/src/Contracts/ConditionallyIgnored.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Surveyor\Contracts;
+
+/**
+ * An ignore marker that only applies some of the time.
+ *
+ * Conditions are resolved when the marked declaration is read, not while the
+ * file is analyzed, so a cached analysis holds the condition rather than the
+ * answer to it. Each condition is a config key or a [class, method] callable,
+ * or null for "not set".
+ */
+interface ConditionallyIgnored extends Ignored
+{
+    /**
+     * Keep the declaration while this passes.
+     */
+    public function unless(): string|array|null;
+
+    /**
+     * Leave the declaration out while this passes.
+     */
+    public function when(): string|array|null;
+}

--- a/src/Contracts/Ignored.php
+++ b/src/Contracts/Ignored.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Laravel\Surveyor\Contracts;
+
+/**
+ * Marks an attribute class as meaning "leave this out of generated output".
+ *
+ * Consumers ship their own attribute implementing this, so users write a name
+ * from the package they installed while surveyor stays free of any one
+ * consumer's vocabulary.
+ */
+interface Ignored
+{
+    //
+}

--- a/src/NodeResolvers/Expr/Array_.php
+++ b/src/NodeResolvers/Expr/Array_.php
@@ -3,6 +3,7 @@
 namespace Laravel\Surveyor\NodeResolvers\Expr;
 
 use Laravel\Surveyor\NodeResolvers\AbstractResolver;
+use Laravel\Surveyor\NodeResolvers\Shared\ResolvesIgnoreMarkers;
 use Laravel\Surveyor\Result\VariableState;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
@@ -11,6 +12,8 @@ use PhpParser\Node;
 
 class Array_ extends AbstractResolver
 {
+    use ResolvesIgnoreMarkers;
+
     public function resolve(Node\Expr\Array_ $node)
     {
         if ($this->isListArray($node)) {
@@ -48,9 +51,10 @@ class Array_ extends AbstractResolver
     protected function resolveListArray(Node\Expr\Array_ $node)
     {
         $result = [];
+        $ignored = $this->ignoredArrayItems($node);
 
-        foreach ($node->items as $item) {
-            if ($item === null) {
+        foreach ($node->items as $index => $item) {
+            if ($item === null || isset($ignored[$index])) {
                 continue;
             }
 
@@ -75,9 +79,10 @@ class Array_ extends AbstractResolver
     protected function resolveKeyedArray(Node\Expr\Array_ $node)
     {
         $result = [];
+        $ignored = $this->ignoredArrayItems($node);
 
-        foreach ($node->items as $item) {
-            if ($item === null) {
+        foreach ($node->items as $index => $item) {
+            if ($item === null || isset($ignored[$index])) {
                 continue;
             }
 

--- a/src/NodeResolvers/Shared/ResolvesIgnoreMarkers.php
+++ b/src/NodeResolvers/Shared/ResolvesIgnoreMarkers.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Laravel\Surveyor\NodeResolvers\Shared;
+
+use Laravel\Surveyor\Analyzed\IgnoreMarker;
+use Laravel\Surveyor\Support\Markers;
+use PhpParser\Node;
+
+trait ResolvesIgnoreMarkers
+{
+    protected function ignoreMarker(Node $node): ?IgnoreMarker
+    {
+        foreach ($node->attrGroups ?? [] as $group) {
+            foreach ($group->attrs as $attribute) {
+                foreach ($this->resolveAttributeNames($attribute) as $name) {
+                    if (! Markers::isIgnoreAttribute($name)) {
+                        continue;
+                    }
+
+                    if (! Markers::acceptsConditions($name)) {
+                        return new IgnoreMarker;
+                    }
+
+                    return new IgnoreMarker(
+                        $this->resolveIgnoreCondition($attribute, $name, 'unless'),
+                        $this->resolveIgnoreCondition($attribute, $name, 'when'),
+                    );
+                }
+            }
+        }
+
+        return $this->hasIgnoreTag($node) ? new IgnoreMarker : null;
+    }
+
+    /**
+     * Read one of the conditions an attribute was written with. Attribute
+     * arguments are constant expressions, so the value is in the file: nothing
+     * is called, and nothing is loaded, to find it.
+     */
+    protected function resolveIgnoreCondition(Node\Attribute $attribute, string $class, string $name): string|array|null
+    {
+        foreach ($attribute->args as $index => $argument) {
+            $argumentName = $argument->name?->toString()
+                ?? Markers::constructorParameterName($class, $index);
+
+            if ($argumentName === $name) {
+                return $this->constantValue($argument->value);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * An expression this does not understand comes back as null, which leaves
+     * the declaration hidden either way.
+     */
+    protected function constantValue(Node\Expr $expression): string|array|null
+    {
+        if ($expression instanceof Node\Scalar\String_) {
+            return $expression->value;
+        }
+
+        if ($expression instanceof Node\Expr\ClassConstFetch
+            && $expression->name instanceof Node\Identifier
+            && $expression->name->toString() === 'class'
+            && $expression->class instanceof Node\Name) {
+            return $expression->class instanceof Node\Name\FullyQualified
+                ? $expression->class->toString()
+                : $this->scope->getUse($expression->class->toString());
+        }
+
+        if ($expression instanceof Node\Expr\Array_) {
+            $values = [];
+
+            foreach ($expression->items as $item) {
+                if ($item === null) {
+                    continue;
+                }
+
+                $value = $this->constantValue($item->value);
+
+                if ($value === null) {
+                    return null;
+                }
+
+                $values[] = $value;
+            }
+
+            return $values;
+        }
+
+        return null;
+    }
+
+    /**
+     * Only a doc block counts on a declaration. A trailing line comment is
+     * handed by the parser to whatever declaration comes next, so honoring one
+     * would hide a neighbour instead of the member the author was looking at.
+     */
+    protected function hasIgnoreTag(Node $node): bool
+    {
+        $docBlock = $node->getDocComment();
+
+        return $docBlock !== null && Markers::commentHasIgnoreTag($docBlock->getText());
+    }
+
+    /**
+     * Work out which items of an array literal carry an ignore marker, by
+     * position rather than by what the parser attached the comment to.
+     *
+     * @return array<int, true>
+     */
+    protected function ignoredArrayItems(Node\Expr\Array_ $node): array
+    {
+        $markers = $this->scope->ignoreMarkerComments();
+
+        if ($markers === []) {
+            return [];
+        }
+
+        $items = [];
+
+        foreach ($node->items as $index => $item) {
+            if ($item !== null) {
+                $items[$index] = $item;
+            }
+        }
+
+        $ignored = [];
+
+        foreach ($markers as $marker) {
+            if ($marker['pos'] < $node->getStartFilePos() || $marker['pos'] > $node->getEndFilePos()) {
+                continue;
+            }
+
+            $owner = $this->markerOwner($items, $marker);
+
+            if ($owner !== null) {
+                $ignored[$owner] = true;
+            }
+        }
+
+        return $ignored;
+    }
+
+    /**
+     * @param  array<int, Node\ArrayItem>  $items
+     * @param  array{pos: int, line: int}  $marker
+     */
+    protected function markerOwner(array $items, array $marker): ?int
+    {
+        $previous = null;
+        $next = null;
+
+        foreach ($items as $index => $item) {
+            if ($marker['pos'] >= $item->getStartFilePos() && $marker['pos'] <= $item->getEndFilePos()) {
+                // The marker sits inside an item, so it belongs to an array
+                // nested in this one and is resolved at that level instead.
+                return null;
+            }
+
+            if ($item->getEndFilePos() < $marker['pos']) {
+                $previous = $index;
+
+                continue;
+            }
+
+            $next ??= $index;
+        }
+
+        // A marker left at the end of a line belongs to the item on that line,
+        // unless another item follows it there.
+        if ($previous !== null
+            && $items[$previous]->getEndLine() === $marker['line']
+            && ($next === null || $items[$next]->getStartLine() > $marker['line'])) {
+            return $previous;
+        }
+
+        return $next;
+    }
+
+    /**
+     * A short name can reach its class through an import, an alias, or the
+     * current namespace, so hand back every candidate rather than guessing.
+     *
+     * @return list<string>
+     */
+    protected function resolveAttributeNames(Node\Attribute $attribute): array
+    {
+        $written = $attribute->name->toString();
+
+        if ($attribute->name instanceof Node\Name\FullyQualified) {
+            return [$written];
+        }
+
+        return array_values(array_unique([
+            $written,
+            $this->scope->getUse($written),
+            $this->scope->resolveBuggyUse($written),
+        ]));
+    }
+}

--- a/src/NodeResolvers/Stmt/ClassMethod.php
+++ b/src/NodeResolvers/Stmt/ClassMethod.php
@@ -10,6 +10,7 @@ use Laravel\Surveyor\Analyzed\ClassLikeResult;
 use Laravel\Surveyor\Analyzed\MethodResult;
 use Laravel\Surveyor\Analyzed\PropertyResult;
 use Laravel\Surveyor\NodeResolvers\AbstractResolver;
+use Laravel\Surveyor\NodeResolvers\Shared\ResolvesIgnoreMarkers;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 use Laravel\Surveyor\Types\StringType;
@@ -18,6 +19,8 @@ use PhpParser\Node;
 
 class ClassMethod extends AbstractResolver
 {
+    use ResolvesIgnoreMarkers;
+
     public function resolve(Node\Stmt\ClassMethod $node)
     {
         $this->scope->setMethodName($node->name);
@@ -26,6 +29,10 @@ class ClassMethod extends AbstractResolver
         $result = new MethodResult(
             name: $this->scope->methodName(),
         );
+
+        if ($marker = $this->ignoreMarker($node)) {
+            $result->flagAsIgnored($marker);
+        }
 
         $this->scope->attachResult($result);
 
@@ -48,6 +55,7 @@ class ClassMethod extends AbstractResolver
                             $param->isPrivate() => 'private',
                             default => 'public',
                         },
+                        ignore: $this->ignoreMarker($param),
                     ),
                 );
             }

--- a/src/NodeResolvers/Stmt/Class_.php
+++ b/src/NodeResolvers/Stmt/Class_.php
@@ -11,6 +11,7 @@ use Laravel\Surveyor\Analyzer\ModelAnalyzer;
 use Laravel\Surveyor\Analyzer\ResourceAnalyzer;
 use Laravel\Surveyor\NodeResolvers\AbstractResolver;
 use Laravel\Surveyor\NodeResolvers\Shared\ParsesClassLikeDocBlock;
+use Laravel\Surveyor\NodeResolvers\Shared\ResolvesIgnoreMarkers;
 use Laravel\Surveyor\Types\Type;
 use PhpParser\Node;
 use PhpParser\NodeAbstract;
@@ -19,6 +20,7 @@ use Throwable;
 class Class_ extends AbstractResolver
 {
     use ParsesClassLikeDocBlock;
+    use ResolvesIgnoreMarkers;
 
     public function resolve(Node\Stmt\Class_ $node)
     {
@@ -45,6 +47,10 @@ class Class_ extends AbstractResolver
             filePath: $this->scope->fullPath(),
             entityType: EntityType::CLASS_TYPE,
         );
+
+        if ($marker = $this->ignoreMarker($node)) {
+            $result->flagAsIgnored($marker);
+        }
 
         $this->scope->attachResult($result);
 

--- a/src/NodeResolvers/Stmt/Interface_.php
+++ b/src/NodeResolvers/Stmt/Interface_.php
@@ -6,6 +6,7 @@ use Laravel\Surveyor\Analysis\EntityType;
 use Laravel\Surveyor\Analyzed\ClassLikeResult;
 use Laravel\Surveyor\NodeResolvers\AbstractResolver;
 use Laravel\Surveyor\NodeResolvers\Shared\ParsesClassLikeDocBlock;
+use Laravel\Surveyor\NodeResolvers\Shared\ResolvesIgnoreMarkers;
 use Laravel\Surveyor\Types\Type;
 use PhpParser\Node;
 use Throwable;
@@ -13,6 +14,7 @@ use Throwable;
 class Interface_ extends AbstractResolver
 {
     use ParsesClassLikeDocBlock;
+    use ResolvesIgnoreMarkers;
 
     public function resolve(Node\Stmt\Interface_ $node)
     {
@@ -30,6 +32,10 @@ class Interface_ extends AbstractResolver
             filePath: $this->scope->fullPath(),
             entityType: EntityType::INTERFACE_TYPE,
         );
+
+        if ($marker = $this->ignoreMarker($node)) {
+            $result->flagAsIgnored($marker);
+        }
 
         $this->scope->attachResult($result);
 

--- a/src/NodeResolvers/Stmt/Property.php
+++ b/src/NodeResolvers/Stmt/Property.php
@@ -5,11 +5,14 @@ namespace Laravel\Surveyor\NodeResolvers\Stmt;
 use Laravel\Surveyor\Analyzed\ClassLikeResult;
 use Laravel\Surveyor\Analyzed\PropertyResult;
 use Laravel\Surveyor\NodeResolvers\AbstractResolver;
+use Laravel\Surveyor\NodeResolvers\Shared\ResolvesIgnoreMarkers;
 use Laravel\Surveyor\Types\Type;
 use PhpParser\Node;
 
 class Property extends AbstractResolver
 {
+    use ResolvesIgnoreMarkers;
+
     public function resolve(Node\Stmt\Property $node)
     {
         foreach ($node->props as $prop) {
@@ -54,6 +57,7 @@ class Property extends AbstractResolver
                         default => 'public',
                     },
                     fromDocBlock: $node->getDocComment() ? true : false,
+                    ignore: $this->ignoreMarker($node),
                 ),
             );
         }

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -4,6 +4,7 @@ namespace Laravel\Surveyor\Parser;
 
 use Laravel\Surveyor\Analysis\Scope;
 use Laravel\Surveyor\Resolvers\NodeResolver;
+use Laravel\Surveyor\Support\Markers;
 use Laravel\Surveyor\Visitors\TypeResolver;
 use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
@@ -66,6 +67,7 @@ class Parser
         };
 
         $this->typeResolver->newScope($path);
+        $this->typeResolver->scope()->setIgnoreMarkerComments(Markers::markerComments($code));
 
         return $this->nodeTraverser->traverse($this->parser->parse($code));
     }

--- a/src/Support/Markers.php
+++ b/src/Support/Markers.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Laravel\Surveyor\Support;
+
+use Laravel\Surveyor\Analyzed\IgnoreMarker;
+use Laravel\Surveyor\Contracts\ConditionallyIgnored;
+use Laravel\Surveyor\Contracts\Ignored;
+use ReflectionClass;
+use ReflectionParameter;
+use Throwable;
+
+class Markers
+{
+    /**
+     * Extra attribute class names treated as ignore markers, for attributes
+     * that cannot implement the Ignored contract, such as vendor attributes.
+     *
+     * @var list<string>
+     */
+    protected static array $attributes = [];
+
+    /**
+     * Doc block and comment tags treated as ignore markers, without the "@".
+     *
+     * @var list<string>
+     */
+    protected static array $tags = [];
+
+    /** @var array<string, bool> */
+    protected static array $resolved = [];
+
+    /** @var array<string, bool> */
+    protected static array $conditional = [];
+
+    /** @var array<string, list<string>> */
+    protected static array $constructorParameters = [];
+
+    /** @var (callable(string|array): bool)|null */
+    protected static $conditionResolver = null;
+
+    /** @var array<string, bool> */
+    protected static array $conditions = [];
+
+    public static function registerAttributes(string ...$attributes): void
+    {
+        static::$attributes = array_values(array_unique([
+            ...static::$attributes,
+            ...array_map(fn (string $attribute) => ltrim($attribute, '\\'), $attributes),
+        ]));
+
+        static::$resolved = [];
+        static::$conditional = [];
+    }
+
+    public static function registerTags(string ...$tags): void
+    {
+        static::$tags = array_values(array_unique([
+            ...static::$tags,
+            ...array_map(fn (string $tag) => ltrim($tag, '@'), $tags),
+        ]));
+    }
+
+    /**
+     * Hand over the resolving of marker conditions. Surveyor knows what a
+     * condition is, not what a config key means.
+     *
+     * @param  (callable(string|array): bool)|null  $resolver
+     */
+    public static function registerConditionResolver(?callable $resolver): void
+    {
+        static::$conditionResolver = $resolver;
+        static::$conditions = [];
+    }
+
+    /**
+     * Whether anything is able to answer a condition at all. Without a resolver
+     * a condition is unanswerable, which is not the same as failing.
+     */
+    public static function canResolveConditions(): bool
+    {
+        return static::$conditionResolver !== null;
+    }
+
+    public static function conditionPasses(string|array|null $condition): bool
+    {
+        if ($condition === null) {
+            return false;
+        }
+
+        if (static::$conditionResolver === null) {
+            return false;
+        }
+
+        return static::$conditions[serialize($condition)] ??= (bool) (static::$conditionResolver)($condition);
+    }
+
+    public static function isIgnoreAttribute(string $class): bool
+    {
+        $class = ltrim($class, '\\');
+
+        return static::$resolved[$class] ??= static::resolveIgnoreAttribute($class);
+    }
+
+    /**
+     * Whether a marker takes conditions at all. An attribute that is
+     * unconditional by contract must not be turned off by an argument its class
+     * would refuse: nothing is instantiated while reading a file, so the error
+     * PHP would raise never happens.
+     */
+    public static function acceptsConditions(string $class): bool
+    {
+        $class = ltrim($class, '\\');
+
+        return static::$conditional[$class] ??= class_exists($class)
+            && is_subclass_of($class, ConditionallyIgnored::class);
+    }
+
+    /**
+     * The name a positional argument carries, taken from the marker's own
+     * constructor rather than assumed, so the reading of an attribute in a file
+     * matches what instantiating it would produce.
+     */
+    public static function constructorParameterName(string $class, int $position): ?string
+    {
+        $class = ltrim($class, '\\');
+
+        if (! isset(static::$constructorParameters[$class])) {
+            try {
+                $parameters = (new ReflectionClass($class))->getConstructor()?->getParameters() ?? [];
+            } catch (Throwable) {
+                $parameters = [];
+            }
+
+            static::$constructorParameters[$class] = array_map(
+                fn (ReflectionParameter $parameter) => $parameter->getName(),
+                $parameters,
+            );
+        }
+
+        return static::$constructorParameters[$class][$position] ?? null;
+    }
+
+    public static function commentHasIgnoreTag(string $comment): bool
+    {
+        foreach (static::$tags as $tag) {
+            if (preg_match('/@'.preg_quote($tag, '/').'\b/i', $comment) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Find every comment in a file carrying an ignore tag, with the byte offset
+     * it starts at. The parser hands a comment to the node that follows it,
+     * which for an array key is the wrong key, and for the last key is no node
+     * at all, so array items are matched on position instead.
+     *
+     * @return list<array{pos: int, line: int}>
+     */
+    public static function markerComments(string $code): array
+    {
+        if (static::$tags === []) {
+            return [];
+        }
+
+        $tags = implode('|', array_map(fn (string $tag) => preg_quote($tag, '/'), static::$tags));
+
+        if (! preg_match_all('/(?:\/\/|#|\/\*+|\*)[^\n]*?@(?:'.$tags.')\b/i', $code, $matches, PREG_OFFSET_CAPTURE)) {
+            return [];
+        }
+
+        return array_map(fn (array $match) => [
+            'pos' => $match[1],
+            'line' => substr_count($code, "\n", 0, $match[1]) + 1,
+        ], $matches[0]);
+    }
+
+    /**
+     * Read the marker off a declaration through reflection, for members the
+     * file being analyzed does not declare itself, such as one reached through
+     * a trait or a parent class.
+     *
+     * @param  ReflectionClass<object>|\ReflectionClassConstant|\ReflectionEnum|\ReflectionEnumBackedCase|\ReflectionEnumUnitCase|\ReflectionMethod|\ReflectionProperty  $reflection
+     */
+    public static function fromReflection(object $reflection): ?IgnoreMarker
+    {
+        foreach ($reflection->getAttributes() as $attribute) {
+            if (! static::isIgnoreAttribute($attribute->getName())) {
+                continue;
+            }
+
+            try {
+                $instance = $attribute->newInstance();
+            } catch (Throwable) {
+                // A marker that cannot be built still means the author wanted
+                // this left out, so hide it either way.
+                return new IgnoreMarker;
+            }
+
+            return $instance instanceof ConditionallyIgnored
+                ? new IgnoreMarker($instance->unless(), $instance->when())
+                : new IgnoreMarker;
+        }
+
+        $docBlock = $reflection->getDocComment();
+
+        return $docBlock !== false && static::commentHasIgnoreTag($docBlock)
+            ? new IgnoreMarker
+            : null;
+    }
+
+    public static function reset(): void
+    {
+        static::$attributes = [];
+        static::$tags = [];
+        static::$resolved = [];
+        static::$conditional = [];
+        static::$constructorParameters = [];
+        static::$conditionResolver = null;
+        static::$conditions = [];
+    }
+
+    protected static function resolveIgnoreAttribute(string $class): bool
+    {
+        if (in_array($class, static::$attributes, true)) {
+            return true;
+        }
+
+        return (class_exists($class) || interface_exists($class))
+            && is_subclass_of($class, Ignored::class);
+    }
+}

--- a/tests/Unit/IgnoreMarkersTest.php
+++ b/tests/Unit/IgnoreMarkersTest.php
@@ -1,0 +1,983 @@
+<?php
+
+use App\Attributes\Ignore;
+use App\Attributes\Unrelated;
+use App\Models\Note;
+use App\PositionalAgreement;
+use App\Support\MarkedByReflection;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Surveyor\Analyzed\IgnoreMarker;
+use Laravel\Surveyor\Analyzer\AnalyzedCache;
+use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Support\Markers;
+
+uses()->group('integration');
+
+beforeEach(function () {
+    AnalyzedCache::clear();
+    Markers::reset();
+    Markers::registerTags('wayfinder-ignore', 'ignore');
+});
+
+afterEach(function () {
+    AnalyzedCache::clear();
+    Markers::reset();
+});
+
+function marker(string $property): ?IgnoreMarker
+{
+    return Markers::fromReflection(
+        new ReflectionProperty(MarkedByReflection::class, $property),
+    );
+}
+
+/**
+ * @return list<string>
+ */
+function attributeNames(string $model): array
+{
+    return array_map(
+        fn ($property) => $property->name,
+        app(Analyzer::class)->analyzeClass($model)->result()->publicProperties(),
+    );
+}
+
+function analyzeFixture(string $code)
+{
+    $fixture = createPhpFixture($code);
+
+    try {
+        return app(Analyzer::class)->analyze($fixture)->result();
+    } finally {
+        unlink($fixture);
+    }
+}
+
+describe('array item markers', function () {
+    it('drops a key marked on the line above', function () {
+        $result = analyzeFixture('
+namespace App;
+
+class LeadingMarker
+{
+    public function toArray(): array
+    {
+        return [
+            "name" => "Taylor",
+            // @ignore
+            "ssn" => "secret",
+            "email" => "taylor@laravel.com",
+        ];
+    }
+}');
+
+        expect(array_keys($result->getMethod('toArray')->returnType()->value))
+            ->toBe(['name', 'email']);
+    });
+
+    it('drops the key a trailing marker sits on, not the one after it', function () {
+        $result = analyzeFixture('
+namespace App;
+
+class TrailingMarker
+{
+    public function toArray(): array
+    {
+        return [
+            "name" => "Taylor",
+            "ssn" => "secret", // @ignore
+            "email" => "taylor@laravel.com",
+        ];
+    }
+}');
+
+        expect(array_keys($result->getMethod('toArray')->returnType()->value))
+            ->toBe(['name', 'email']);
+    });
+
+    it('drops the last key when the marker trails it', function () {
+        $result = analyzeFixture('
+namespace App;
+
+class TrailingLastMarker
+{
+    public function toArray(): array
+    {
+        return [
+            "name" => "Taylor",
+            "ssn" => "secret", // @ignore
+        ];
+    }
+}');
+
+        expect(array_keys($result->getMethod('toArray')->returnType()->value))
+            ->toBe(['name']);
+    });
+
+    it('drops the key a marker precedes on the same line', function () {
+        $result = analyzeFixture('
+namespace App;
+
+class InlineMarker
+{
+    public function toArray(): array
+    {
+        return ["name" => "Taylor", /* @ignore */ "ssn" => "secret"];
+    }
+}');
+
+        expect(array_keys($result->getMethod('toArray')->returnType()->value))
+            ->toBe(['name']);
+    });
+
+    it('only drops the nested key a nested marker belongs to', function () {
+        $result = analyzeFixture('
+namespace App;
+
+class NestedMarker
+{
+    public function toArray(): array
+    {
+        return [
+            "user" => [
+                "name" => "Taylor",
+                "ssn" => "secret", // @ignore
+            ],
+            "email" => "taylor@laravel.com",
+        ];
+    }
+}');
+
+        $shape = $result->getMethod('toArray')->returnType()->value;
+
+        expect(array_keys($shape))->toBe(['user', 'email']);
+        expect(array_keys($shape['user']->value))->toBe(['name']);
+    });
+
+    it('drops a whole nested block when the marker trails it', function () {
+        $result = analyzeFixture('
+namespace App;
+
+class NestedBlockMarker
+{
+    public function toArray(): array
+    {
+        return [
+            "user" => [
+                "name" => "Taylor",
+            ], // @ignore
+            "email" => "taylor@laravel.com",
+        ];
+    }
+}');
+
+        expect(array_keys($result->getMethod('toArray')->returnType()->value))
+            ->toBe(['email']);
+    });
+
+    it('leaves keys alone when a marker sits outside the array', function () {
+        $result = analyzeFixture('
+namespace App;
+
+class MarkerOutsideArray
+{
+    /** @ignore */
+    public function toArray(): array
+    {
+        return [
+            "name" => "Taylor",
+            "email" => "taylor@laravel.com",
+        ];
+    }
+}');
+
+        // The doc block hides the method itself, so read past the filter to
+        // check that it did not also take the first key of the array with it.
+        expect($result->hasMethod('toArray'))->toBeFalse();
+        expect(array_keys($result->method('toArray')->returnType()->value))
+            ->toBe(['name', 'email']);
+    });
+
+    it('drops items from a list array', function () {
+        $result = analyzeFixture('
+namespace App;
+
+class ListMarker
+{
+    public function toArray(): array
+    {
+        return [
+            "one",
+            // @ignore
+            "two",
+            "three",
+        ];
+    }
+}');
+
+        $values = array_map(fn ($type) => $type->value, $result->getMethod('toArray')->returnType()->value);
+
+        expect($values)->toBe(['one', 'three']);
+    });
+
+    it('keeps marked keys when no tag is registered', function () {
+        Markers::reset();
+
+        $result = analyzeFixture('
+namespace App;
+
+class NoTagsRegistered
+{
+    public function toArray(): array
+    {
+        return [
+            "name" => "Taylor",
+            "ssn" => "secret", // @ignore
+        ];
+    }
+}');
+
+        expect(array_keys($result->getMethod('toArray')->returnType()->value))
+            ->toBe(['name', 'ssn']);
+    });
+});
+
+describe('attribute markers', function () {
+    it('hides a property marked with an attribute implementing the contract', function () {
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\Ignore;
+
+class AttributeOnProperty
+{
+    public string $name = "Taylor";
+
+    #[Ignore]
+    public string $ssn = "secret";
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['name']);
+    });
+
+    it('hides a property marked through an alias', function () {
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\Ignore as NeverShip;
+
+class AliasedAttribute
+{
+    public string $name = "Taylor";
+
+    #[NeverShip]
+    public string $ssn = "secret";
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['name']);
+    });
+
+    it('hides a property marked with a fully qualified attribute', function () {
+        $result = analyzeFixture('
+namespace App;
+
+class FullyQualifiedAttribute
+{
+    public string $name = "Taylor";
+
+    #[\App\Attributes\Ignore]
+    public string $ssn = "secret";
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['name']);
+    });
+
+    it('hides a promoted constructor property', function () {
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\Ignore;
+
+class PromotedProperty
+{
+    public function __construct(
+        public string $name,
+        #[Ignore]
+        public string $ssn,
+    ) {
+    }
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['name']);
+    });
+
+    it('hides a method', function () {
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\Ignore;
+
+class AttributeOnMethod
+{
+    public function keep(): string
+    {
+        return "keep";
+    }
+
+    #[Ignore]
+    public function secret(): string
+    {
+        return "secret";
+    }
+}');
+
+        expect(array_values(array_map(fn ($method) => $method->name(), $result->publicMethods())))
+            ->toBe(['keep']);
+    });
+
+    it('hides a member marked with a doc block tag', function () {
+        $result = analyzeFixture('
+namespace App;
+
+class DocBlockTag
+{
+    public string $name = "Taylor";
+
+    /** @ignore */
+    public string $ssn = "secret";
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['name']);
+    });
+
+    it('honors an attribute registered by name', function () {
+        Markers::registerAttributes(Unrelated::class);
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\Unrelated;
+
+class RegisteredByName
+{
+    public string $name = "Taylor";
+
+    #[Unrelated]
+    public string $ssn = "secret";
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['name']);
+    });
+
+    it('flags a class', function () {
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\Ignore;
+
+#[Ignore]
+class IgnoredClass
+{
+    public string $name = "Taylor";
+}');
+
+        expect($result->isIgnored())->toBeTrue();
+    });
+
+    it('flags an interface', function () {
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\Ignore;
+
+#[Ignore]
+interface IgnoredContract
+{
+    public function handle(): void;
+}');
+
+        expect($result->isIgnored())->toBeTrue();
+    });
+
+    it('flags an interface only while its condition fails', function () {
+        Markers::registerConditionResolver(fn ($condition) => $condition === 'features.fake');
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+
+#[ConditionalIgnore(unless: "features.fake")]
+interface ConditionalContract
+{
+    public function handle(): void;
+}');
+
+        expect($result->isIgnored())->toBeFalse();
+
+        Markers::registerConditionResolver(fn ($condition) => false);
+
+        expect($result->isIgnored())->toBeTrue();
+    });
+
+    it('leaves an unmarked class alone', function () {
+        $result = analyzeFixture('
+namespace App;
+
+class PlainClass
+{
+    public string $name = "Taylor";
+}');
+
+        expect($result->isIgnored())->toBeFalse();
+    });
+});
+
+describe('reading a member by name', function () {
+    it('hides a marked method from every way of reading it', function () {
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\Ignore;
+use Illuminate\Contracts\Support\Arrayable;
+
+class MarkedToArray implements Arrayable
+{
+    #[Ignore]
+    public function toArray(): array
+    {
+        return ["ssn" => "000-00-0000"];
+    }
+}');
+
+        expect($result->publicMethods())->toBe([]);
+        expect($result->hasMethod('toArray'))->toBeFalse();
+        expect($result->getMethod('toArray'))->toBeNull();
+        expect($result->asArray())->toBeNull();
+    });
+
+    it('hides a marked jsonSerialize from asJson', function () {
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\Ignore;
+use JsonSerializable;
+
+class MarkedJsonSerialize implements JsonSerializable
+{
+    #[Ignore]
+    public function jsonSerialize(): array
+    {
+        return ["ssn" => "000-00-0000"];
+    }
+}');
+
+        expect($result->asJson())->toBeNull();
+    });
+
+    it('hides a marked property from every way of reading it', function () {
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\Ignore;
+
+class MarkedProperty
+{
+    #[Ignore]
+    public string $ssn = "000-00-0000";
+}');
+
+        expect($result->publicProperties())->toBe([]);
+        expect($result->hasProperty('ssn'))->toBeFalse();
+        expect($result->getProperty('ssn'))->toBeNull();
+    });
+
+    it('still reads a marked member through the unfiltered accessors', function () {
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\Ignore;
+
+class RawAccess
+{
+    #[Ignore]
+    public string $ssn = "000-00-0000";
+
+    #[Ignore]
+    public function secret(): string
+    {
+        return "value";
+    }
+}');
+
+        expect($result->property('ssn')?->name)->toBe('ssn');
+        expect($result->method('secret')?->name())->toBe('secret');
+    });
+
+    it('keeps a conditionally marked member readable while its condition passes', function () {
+        Markers::registerConditionResolver(fn ($condition) => $condition === 'features.fake');
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+use Illuminate\Contracts\Support\Arrayable;
+
+class ConditionalToArray implements Arrayable
+{
+    #[ConditionalIgnore(unless: "features.fake")]
+    public function toArray(): array
+    {
+        return ["fake" => true];
+    }
+}');
+
+        expect($result->hasMethod('toArray'))->toBeTrue();
+        expect($result->asArray())->not->toBeNull();
+
+        Markers::registerConditionResolver(fn ($condition) => false);
+
+        expect($result->hasMethod('toArray'))->toBeFalse();
+        expect($result->asArray())->toBeNull();
+    });
+});
+
+describe('marker arguments', function () {
+    it('does not read a condition off a marker that takes none', function () {
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\Ignore;
+
+class ArgumentOnPlainMarker
+{
+    #[Ignore(true)]
+    public string $ssn = "000-00-0000";
+}');
+
+        expect($result->publicProperties())->toBe([]);
+    });
+
+    it('reads a positional condition from the marker own constructor order', function () {
+        Markers::registerConditionResolver(fn ($condition) => $condition === 'features.retired');
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\WhenFirstIgnore;
+
+class WhenFirstPositional
+{
+    public string $name = "Taylor";
+
+    // First position is when for this marker, so a passing condition hides it.
+    #[WhenFirstIgnore("features.retired")]
+    public string $retired = "value";
+
+    #[WhenFirstIgnore("features.other")]
+    public string $kept = "value";
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['name', 'kept']);
+    });
+
+    it('agrees with what instantiating the marker would produce', function () {
+        Markers::registerConditionResolver(fn ($condition) => $condition === 'features.retired');
+
+        $fixture = createPhpFixture('
+namespace App;
+
+use App\Attributes\WhenFirstIgnore;
+
+class PositionalAgreement
+{
+    #[WhenFirstIgnore("features.retired")]
+    public string $retired = "value";
+}');
+
+        $result = app(Analyzer::class)->analyze($fixture)->result();
+
+        require $fixture;
+
+        $reflected = Markers::fromReflection(
+            (new ReflectionClass(PositionalAgreement::class))->getProperty('retired'),
+        );
+
+        expect($result->property('retired')->ignoreMarker()->hides())->toBe($reflected->hides());
+        expect($reflected->hides())->toBeTrue();
+
+        unlink($fixture);
+    });
+
+    it('does not read a condition off an attribute registered by name', function () {
+        Markers::registerAttributes(Unrelated::class);
+        Markers::registerConditionResolver(fn ($condition) => true);
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\Unrelated;
+
+class RegisteredWithArgument
+{
+    #[Unrelated("features.fake")]
+    public string $ssn = "000-00-0000";
+}');
+
+        expect($result->publicProperties())->toBe([]);
+    });
+});
+
+describe('conditional markers', function () {
+    it('keeps a member when the condition passes', function () {
+        Markers::registerConditionResolver(fn ($condition) => $condition === 'features.fake');
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+
+class ConditionPasses
+{
+    public string $name = "Taylor";
+
+    #[ConditionalIgnore(unless: "features.fake")]
+    public string $fake = "value";
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['name', 'fake']);
+    });
+
+    it('hides a member when the condition fails', function () {
+        Markers::registerConditionResolver(fn ($condition) => false);
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+
+class ConditionFails
+{
+    public string $name = "Taylor";
+
+    #[ConditionalIgnore(unless: "features.fake")]
+    public string $fake = "value";
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['name']);
+    });
+
+    it('reads the condition from a positional argument', function () {
+        Markers::registerConditionResolver(fn ($condition) => $condition === 'features.fake');
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+
+class PositionalCondition
+{
+    #[ConditionalIgnore("features.fake")]
+    public string $fake = "value";
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['fake']);
+    });
+
+    it('reads a callable condition', function () {
+        Markers::registerConditionResolver(
+            fn ($condition) => $condition === [Ignore::class, 'enabled'],
+        );
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+use App\Attributes\Ignore;
+
+class CallableCondition
+{
+    #[ConditionalIgnore(unless: [Ignore::class, "enabled"])]
+    public string $fake = "value";
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['fake']);
+    });
+
+    it('does not treat a bool as a condition, so the marker still hides', function () {
+        Markers::registerConditionResolver(fn ($condition) => true);
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+
+class BoolCondition
+{
+    #[ConditionalIgnore(unless: true)]
+    public string $named = "value";
+
+    #[ConditionalIgnore(true)]
+    public string $positional = "value";
+
+    #[ConditionalIgnore(when: false)]
+    public string $when = "value";
+}');
+
+        expect($result->publicProperties())->toBe([]);
+    });
+
+    it('hides both kinds of condition when nothing can answer them', function () {
+        Markers::reset();
+        Markers::registerTags('ignore');
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+
+class NoResolverRegistered
+{
+    public string $name = "Taylor";
+
+    #[ConditionalIgnore(unless: "features.fake")]
+    public string $fake = "value";
+
+    #[ConditionalIgnore(when: "features.retired")]
+    public string $retired = "value";
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['name']);
+    });
+
+    it('does not treat a malformed callable as a condition', function () {
+        Markers::registerConditionResolver(fn ($condition) => true);
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+
+class MalformedCallable
+{
+    #[ConditionalIgnore(unless: ["only-one-element"])]
+    public string $ssn = "value";
+}');
+
+        expect($result->publicProperties())->toBe([]);
+    });
+
+    it('hides a member when a when condition passes', function () {
+        Markers::registerConditionResolver(fn ($condition) => $condition === 'features.retired');
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+
+class WhenPasses
+{
+    public string $name = "Taylor";
+
+    #[ConditionalIgnore(when: "features.retired")]
+    public string $retired = "value";
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['name']);
+    });
+
+    it('keeps a member when a when condition fails', function () {
+        Markers::registerConditionResolver(fn ($condition) => false);
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+
+class WhenFails
+{
+    public string $name = "Taylor";
+
+    #[ConditionalIgnore(when: "features.retired")]
+    public string $retired = "value";
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['name', 'retired']);
+    });
+
+    it('hides a member when either condition asks for it', function () {
+        Markers::registerConditionResolver(fn ($condition) => $condition === 'features.retired');
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+
+class BothConditions
+{
+    // Kept by unless, hidden by when: hiding wins.
+    #[ConditionalIgnore(unless: "features.retired", when: "features.retired")]
+    public string $retired = "value";
+
+    #[ConditionalIgnore(unless: "features.retired", when: "features.other")]
+    public string $kept = "value";
+}');
+
+        expect(array_map(fn ($property) => $property->name, $result->publicProperties()))
+            ->toBe(['kept']);
+    });
+
+    it('hides a member when a when condition cannot be read', function () {
+        Markers::registerConditionResolver(fn ($condition) => false);
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+
+class UnreadableWhenCondition
+{
+    #[ConditionalIgnore(when: SOME_UNDEFINED_CONSTANT)]
+    public string $retired = "value";
+}');
+
+        expect($result->publicProperties())->toBe([]);
+    });
+
+    it('hides a member when the condition cannot be read', function () {
+        Markers::registerConditionResolver(fn ($condition) => true);
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+
+class UnreadableCondition
+{
+    #[ConditionalIgnore(unless: SOME_UNDEFINED_CONSTANT)]
+    public string $fake = "value";
+}');
+
+        expect($result->publicProperties())->toBe([]);
+    });
+
+    it('resolves the condition each time rather than baking it into the analysis', function () {
+        Markers::registerConditionResolver(fn ($condition) => true);
+
+        $result = analyzeFixture('
+namespace App;
+
+use App\Attributes\ConditionalIgnore;
+
+class ResolvedLate
+{
+    #[ConditionalIgnore(unless: "features.fake")]
+    public string $fake = "value";
+}');
+
+        expect($result->publicProperties())->toHaveCount(1);
+
+        Markers::registerConditionResolver(fn ($condition) => false);
+
+        expect($result->publicProperties())->toBe([]);
+    });
+});
+
+describe('reading a marker through reflection', function () {
+    it('reads a marker off a property', function () {
+        expect(marker('marked')?->hides())->toBeTrue();
+    });
+
+    it('reads a marker off a method', function () {
+        $method = new ReflectionMethod(MarkedByReflection::class, 'markedMethod');
+
+        expect(Markers::fromReflection($method)?->hides())->toBeTrue();
+    });
+
+    it('reads a marker off a class', function () {
+        $class = new ReflectionClass(Ignore::class);
+
+        expect(Markers::fromReflection($class))->toBeNull();
+    });
+
+    it('reads nothing off an unmarked property', function () {
+        expect(marker('plain'))->toBeNull();
+    });
+
+    it('reads nothing off an unrelated attribute', function () {
+        expect(marker('unrelated'))->toBeNull();
+    });
+
+    it('reads a doc block tag', function () {
+        expect(marker('taggedInDocBlock')?->hides())->toBeTrue();
+    });
+
+    it('hides when a marker cannot be built', function () {
+        // #[Ignore(true)] on a marker with no constructor: instantiating throws,
+        // which must not be mistaken for a marker that was switched off.
+        expect(marker('argumentOnPlainMarker')?->hides())->toBeTrue();
+    });
+
+    it('carries the conditions off a conditional marker', function () {
+        Markers::registerConditionResolver(fn ($condition) => $condition === 'features.fake');
+
+        expect(marker('keptWhileFake')?->unless)->toBe('features.fake');
+        expect(marker('keptWhileFake')?->hides())->toBeFalse();
+        expect(marker('hiddenWhileRetired')?->when)->toBe('features.retired');
+        expect(marker('hiddenWhileRetired')?->hides())->toBeFalse();
+
+        Markers::registerConditionResolver(fn ($condition) => $condition === 'features.retired');
+
+        expect(marker('keptWhileFake')?->hides())->toBeTrue();
+        expect(marker('hiddenWhileRetired')?->hides())->toBeTrue();
+    });
+});
+
+describe('markers on inherited members', function () {
+    beforeEach(function () {
+        Schema::create('notes', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+        });
+    });
+
+    afterEach(function () {
+        Schema::dropIfExists('notes');
+    });
+
+    it('hides an accessor marked in a trait or a parent class', function () {
+        $names = attributeNames(Note::class);
+
+        expect($names)->toContain('title');
+        expect($names)->toContain('trait_public');
+        expect($names)->toContain('parent_public');
+        expect($names)->not->toContain('trait_secret');
+        expect($names)->not->toContain('parent_secret');
+    });
+
+    it('carries the condition off an accessor marked in a trait', function () {
+        Markers::registerConditionResolver(fn ($condition) => $condition === 'features.notes');
+
+        expect(attributeNames(Note::class))->toContain('trait_conditional');
+
+        AnalyzedCache::clear();
+        Markers::registerConditionResolver(fn ($condition) => false);
+
+        expect(attributeNames(Note::class))->not->toContain('trait_conditional');
+    });
+});

--- a/workbench/app/Attributes/ConditionalIgnore.php
+++ b/workbench/app/Attributes/ConditionalIgnore.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Attributes;
+
+use Attribute;
+use Laravel\Surveyor\Contracts\ConditionallyIgnored;
+
+#[Attribute(Attribute::TARGET_ALL)]
+class ConditionalIgnore implements ConditionallyIgnored
+{
+    public function __construct(
+        public readonly string|array|null $unless = null,
+        public readonly string|array|null $when = null,
+    ) {
+        //
+    }
+
+    public function unless(): string|array|null
+    {
+        return $this->unless;
+    }
+
+    public function when(): string|array|null
+    {
+        return $this->when;
+    }
+}

--- a/workbench/app/Attributes/Ignore.php
+++ b/workbench/app/Attributes/Ignore.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Attributes;
+
+use Attribute;
+use Laravel\Surveyor\Contracts\Ignored;
+
+#[Attribute(Attribute::TARGET_ALL)]
+class Ignore implements Ignored
+{
+    //
+}

--- a/workbench/app/Attributes/Unrelated.php
+++ b/workbench/app/Attributes/Unrelated.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_ALL)]
+class Unrelated
+{
+    //
+}

--- a/workbench/app/Attributes/WhenFirstIgnore.php
+++ b/workbench/app/Attributes/WhenFirstIgnore.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Attributes;
+
+use Attribute;
+use Laravel\Surveyor\Contracts\ConditionallyIgnored;
+
+/**
+ * Declares its conditions the other way round, to prove a positional argument
+ * is read from the marker's own constructor rather than an assumed order.
+ */
+#[Attribute(Attribute::TARGET_ALL)]
+class WhenFirstIgnore implements ConditionallyIgnored
+{
+    public function __construct(
+        public readonly string|array|null $when = null,
+        public readonly string|array|null $unless = null,
+    ) {
+        //
+    }
+
+    public function unless(): string|array|null
+    {
+        return $this->unless;
+    }
+
+    public function when(): string|array|null
+    {
+        return $this->when;
+    }
+}

--- a/workbench/app/Models/BaseNote.php
+++ b/workbench/app/Models/BaseNote.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use App\Attributes\Ignore;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+
+abstract class BaseNote extends Model
+{
+    public function parentPublic(): Attribute
+    {
+        return Attribute::make(get: fn (): string => 'public');
+    }
+
+    #[Ignore]
+    public function parentSecret(): Attribute
+    {
+        return Attribute::make(get: fn (): string => 'secret');
+    }
+}

--- a/workbench/app/Models/Concerns/HasNotes.php
+++ b/workbench/app/Models/Concerns/HasNotes.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models\Concerns;
+
+use App\Attributes\ConditionalIgnore;
+use App\Attributes\Ignore;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+
+trait HasNotes
+{
+    public function traitPublic(): Attribute
+    {
+        return Attribute::make(get: fn (): string => 'public');
+    }
+
+    #[Ignore]
+    public function traitSecret(): Attribute
+    {
+        return Attribute::make(get: fn (): string => 'secret');
+    }
+
+    #[ConditionalIgnore(unless: 'features.notes')]
+    public function traitConditional(): Attribute
+    {
+        return Attribute::make(get: fn (): string => 'conditional');
+    }
+}

--- a/workbench/app/Models/Note.php
+++ b/workbench/app/Models/Note.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Concerns\HasNotes;
+
+class Note extends BaseNote
+{
+    use HasNotes;
+
+    protected $table = 'notes';
+}

--- a/workbench/app/Support/MarkedByReflection.php
+++ b/workbench/app/Support/MarkedByReflection.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Support;
+
+use App\Attributes\ConditionalIgnore;
+use App\Attributes\Ignore;
+use App\Attributes\Unrelated;
+
+class MarkedByReflection
+{
+    #[Ignore]
+    public string $marked = 'value';
+
+    #[Unrelated]
+    public string $unrelated = 'value';
+
+    public string $plain = 'value';
+
+    /** @ignore */
+    public string $taggedInDocBlock = 'value';
+
+    #[Ignore(true)]
+    public string $argumentOnPlainMarker = 'value';
+
+    #[ConditionalIgnore(unless: 'features.fake')]
+    public string $keptWhileFake = 'value';
+
+    #[ConditionalIgnore(when: 'features.retired')]
+    public string $hiddenWhileRetired = 'value';
+
+    #[Ignore]
+    public function markedMethod(): string
+    {
+        return 'value';
+    }
+}


### PR DESCRIPTION
Gives an application a way to say "leave this out of generated output" and have everything reading the analysis respect it.

An attribute becomes a marker by implementing `Contracts\Ignored`, so each consumer ships its own name instead of borrowing surveyor's. Marked members are hidden wherever a result hands them out, listing them or looking one up by name, so nothing downstream can pass one on by forgetting to check. method() and property() read past the filter for the caller that needs to inspect a marker rather than act on one.

Markers can carry conditions through `Contracts\ConditionallyIgnored`. Conditions resolve when a member is read rather than while the file is analyzed, so a cached analysis holds the condition and not the answer to it, and the consumer registers what a condition means. Anything unreadable or unanswerable hides rather than ships.

Array keys cannot carry an attribute, so registered comment tags cover those. Keys are matched by position instead of by what the parser attached the comment to, since a trailing comment binds to the next node and is dropped entirely on the last key.

Breaking: getMethod() and getProperty() on ClassLikeResult return null when the member is missing or hidden. Cache entries written by earlier versions are invalidated once.