### PR TITLE
Validate cached analyses against dependency surfaces

### DIFF
--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -192,6 +192,20 @@ determinism still clean, all tests pass.
    nullable, so asking a class in the global namespace for its namespace was a
    fatal error. Fixed on the way past.
 
+   **Slice 2 is done.** Every persisted entry now has a `<md5>.surface` file
+   beside it holding its surface hash, so a dependency can be checked with one
+   small read instead of unserializing its entry. `AnalyzedCache::surfaceHash()`
+   answers from memory, then that file, then by hashing an entry already in
+   memory. Invalidating an entry takes its surface with it.
+
+   It costs nothing in time: cold 18.5s against 18.6s for the same tree without
+   it, warm and edit unchanged. On disk the 3,149 files hold 100KB of hashes and
+   occupy 12MB, all of it filesystem block overhead. That is noise against
+   today's 278MB and about a quarter of what the cache should weigh after slice
+   3, so if it starts to look expensive the answer is one index file rather than
+   3,149 small ones. Kept as files for now: they are written and deleted with
+   the entry they describe, so there is no index to keep in step or repair.
+
 3. **Loose ends, any time.** A regression test for the `Type::union` fix. It
    needs a shared type object reachable from two places, which no current test
    sets up. Debouncing the Vite plugin, which today runs one full build per saved

--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -174,10 +174,23 @@ determinism still clean, all tests pass.
    small side index of path to surface hash so a dependency can be checked
    without loading its whole entry.
 
-   `benchmarks/cache/surfacedump.php` already computes the surface of every
-   entry in a cache directory, and its `--fields` mode hashes each `Scope`
-   property on its own. Whatever the fingerprint ends up hashing should agree
-   with what that script calls a surface, or one of the two is wrong.
+   **Slice 1 is done.** `Analyzer\Surface` is the one definition of what a
+   dependent can see, `surfacedump.php` calls it rather than keeping its own
+   copy, and `tests/Unit/Analyzer/SurfaceTest.php` pins the properties the
+   design needs: a body edit leaves the hash alone, a new public method or a
+   changed return type or a changed import moves it.
+
+   It also turned up the hole that would have sunk the design. 205 of 3,149
+   entries record no result at all, almost all of them enums: nothing analyzes
+   an enum's cases, dependents read them off PHP's reflection, so 89 enums in
+   `App\Enums` all hashed the same and an enum edit moved nothing. Files with
+   nothing observable now hash their own bytes instead, which makes any edit to
+   them count. All 3,149 surfaces are distinct again, and the `edit-enum-case`
+   shape in `shapesweep.sh` is what guards it.
+
+   `ClassLikeResult::namespace()` was declared `: string` while the property is
+   nullable, so asking a class in the global namespace for its namespace was a
+   fatal error. Fixed on the way past.
 
 3. **Loose ends, any time.** A regression test for the `Type::union` fix. It
    needs a shared type object reachable from two places, which no current test

--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -7,29 +7,28 @@ Where something is a calculation rather than a measurement it says so.
 
 ## Where it stands
 
-| | before this work | after discovery and caching | after determinism |
-|---|---|---|---|
-| cold, empty cache | 17.4s | 15.6s | 18.8s |
-| warm, nothing changed | 4.6s | 1.24s | 1.28s |
-| warm, one edit to `Instance.php` | 7.0s | 3.8s | 4.1s |
+| | before this work | after discovery and caching | after determinism | after fingerprints |
+|---|---|---|---|---|
+| cold, empty cache | 17.4s | 15.6s | 18.8s | 16.3s |
+| warm, nothing changed | 4.6s | 1.24s | 1.28s | 1.19s |
+| warm, one edit to `Instance.php` | 7.0s | 3.8s | 4.1s | 1.7s |
 
-The first column predates all of this. The other two are medians of three runs
-each, taken back to back on the same machine.
+The first column predates all of this. The rest are medians of three runs each,
+taken back to back on the same machine. The cache is 62MB, down from 278MB.
 
 Which file you edit still decides the edit path, and closing that spread is what
 step 2 below is for:
 
 | touched | entries rewritten (of 3,149) | time |
 |---|---|---|
-| `app/Models/Instance.php` | 258 | 3.7s |
-| `app/Models/User.php` | 1,370 | 11.2s |
-| `app/Models/Environment.php` | 1,366 | 16.9s |
-| `app/Models/Organization.php` | 1,370 | 19.5s |
+| `app/Models/Instance.php` | 61 | 2.0s |
+| `app/Models/User.php` | 147 | 2.0s |
+| `app/Models/Environment.php` | 230 | 2.7s |
+| `app/Models/Organization.php` | 319 | 2.9s |
 
-One run each. Before the determinism work the same four measured 3.9s, 9.1s,
-15.2s and 16.3s against a nearly identical count of rewritten entries, so
-settling the cycles costs on the edit path too, everywhere except the file whose
-dependents are few.
+One run each, and this is what fingerprinting bought: the same four used to
+rewrite 258, 1,370, 1,366 and 1,370 entries and take 3.7s, 11.2s, 16.9s and
+19.5s. What is left is the file's own dependents whose surfaces really did move.
 
 Analysis is now deterministic: the same bytes give the same answers whatever
 order the files are visited in. That was the blocker on fingerprinting, so
@@ -239,16 +238,43 @@ determinism still clean, all tests pass.
    over-records an edge that is real but indirect. That can only cause extra
    invalidation, never stale output.
 
-3. **Loose ends, any time.** A regression test for the `Type::union` fix. It
-   needs a shared type object reachable from two places, which no current test
-   sets up. Debouncing the Vite plugin, which today runs one full build per saved
-   file, serially.
+3. **Settling narrowed to what moved.** Settling re-analyzed all 333 cycle
+   members. Only 214 of them gave up on a file themselves; the other 119 merely
+   asked one that did, and most of those were handed the same answer either way.
+   Surface hashes make that checkable, so settling now starts with the 214 and
+   pulls in a member only when a file it reached came back with a different
+   surface. That took 16 more, in 7 of the 80 cycles, and never needed a third
+   round: 230 re-analyses instead of 333.
+
+   Cold went from 18.0s to 16.3s, which is 0.7s off the 15.6s from before any of
+   the determinism work. Output is byte identical to settling all 333, checked
+   over the whole of Cloud. Determinism holds at zero flapping surfaces across
+   three targets, and all seven shapes still agree warm against cold.
+
+   The 214 are irreducible while a file is the unit of re-analysis: each of them
+   really did resolve something against nothing. Going below that means the
+   surface pass and body pass split, which is a much larger change and no longer
+   has a measured problem to justify it.
+
+4. **What is left.**
+
+   Every number here comes from one application. The fingerprint rules are fitted
+   to the shape of `laravel/cloud`, and if they are wrong somewhere else the
+   symptom is stale generated types, which is quiet. Pointing `shapesweep.sh`
+   and `determinism.sh` at a second real application is the cheapest insurance
+   available and has not been done.
 
    `StateTracker` is serialised into every cache entry. It holds the variable
    state of the run that produced the entry, nothing reads it back, and it is
    the only thing that still differs between two analyses of the same bytes: 3
-   of 3,149 entries after editing `Organization.php`. Dropping it from what gets
-   persisted would shrink the cache and take those 3 to zero.
+   of 3,149 entries after editing `Organization.php`. It is also held in memory
+   for every entry for the whole run, so dropping it from what gets persisted is
+   about memory and serialisation time more than the 62MB.
+
+   A regression test for the `Type::union` fix. It needs a shared type object
+   reachable from two places, which no current test sets up.
+
+   Debouncing the Vite plugin is done and merged.
 
 ## Dead ends, with numbers
 

--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -256,13 +256,31 @@ determinism still clean, all tests pass.
    surface pass and body pass split, which is a much larger change and no longer
    has a measured problem to justify it.
 
-4. **What is left.**
+4. **Checked against a second application.** Everything above was fitted to
+   `laravel/cloud`, so `laravel/forge` was run through the same guardrails:
+   2,330 files in `app/`, 2,633 cache entries.
 
-   Every number here comes from one application. The fingerprint rules are fitted
-   to the shape of `laravel/cloud`, and if they are wrong somewhere else the
-   symptom is stale generated types, which is quiet. Pointing `shapesweep.sh`
-   and `determinism.sh` at a second real application is the cheapest insurance
-   available and has not been done.
+   | | main | this work |
+   |---|---|---|
+   | cold | 14.3s | 13.5s |
+   | warm, nothing changed | 1.33s | 1.30s |
+   | warm, method added to `Server.php` | 22.7s | 2.7s |
+   | entries rewritten by that edit | 1,269 | 449 |
+   | cache | 258MB | 52MB |
+
+   Determinism holds on four targets, zero flapping surfaces, warm output equal
+   to cold. All seven shapes agree. Nothing about the rules turned out to be
+   specific to Cloud.
+
+   Forge needed setting up first, and its checkout was left alone: its
+   `composer.lock` has no `laravel/wayfinder`, `laravel/surveyor` or
+   `laravel/ranger` in it even though `vendor` symlinks all three, so
+   `composer install` there would delete them. The work was done on a copy, with
+   the three packages plus `spatie/php-structure-discoverer` mapped into
+   `composer.json` by hand and their providers registered in
+   `bootstrap/providers.php`.
+
+5. **What is left.**
 
    `StateTracker` is serialised into every cache entry. It holds the variable
    state of the run that produced the entry, nothing reads it back, and it is
@@ -324,6 +342,10 @@ alongside a timing run reads as a regression.
 - `determinism.sh <label> [target]` builds a cold cache, touches one file
   without changing it, rebuilds, and reports how many entries came back with a
   different surface. Zero is the bar.
+- `SURVEYOR_BENCH_APP` points any of these at another application, and
+  `SURVEYOR_BENCH_PRESET` names the set of files `mutate.py` should edit there.
+  Presets are spelled out per application rather than guessed, because every
+  shape has to change generated output or it proves nothing.
 - `surfacedump.php <cache-dir> [--detail|--fields]` renders a cache directory
   as canonical text: one hash per entry, the surface lines themselves, or a
   hash per `Scope` property to say which part of an entry moved.
@@ -340,7 +362,8 @@ alongside a timing run reads as a regression.
 
 The app loads Surveyor from `vendor`, not from this checkout, so a change here
 reaches a build only after `rsync -a --delete src/ <app>/vendor/laravel/surveyor/src/`.
-`determinism.sh` and `timeit.sh` do that themselves.
+`determinism.sh` and `timeit.sh` do that themselves, and skip it when the app
+symlinks the package straight at a working copy, as Forge does.
 
 Two habits that this work depended on:
 

--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -223,6 +223,10 @@ determinism still clean, all tests pass.
    `.surface`, and the entry itself no longer carries a dependency list at all,
    which is where the 62MB comes from.
 
+   Both the entry and the record carry `AnalyzedCache::SCHEMA`, bumped to 5 by
+   this work, so entries written before it are read as invalid and analyzed
+   again rather than unserialized into a shape that no longer fits.
+
    Deciding whether an entry holds reads records, never entries: the file is
    unchanged and every file it reached is unchanged, or one of them changed and
    has to be analyzed to find out whether the change reached its surface. Each
@@ -280,7 +284,21 @@ determinism still clean, all tests pass.
    `composer.json` by hand and their providers registered in
    `bootstrap/providers.php`.
 
-5. **What is left.**
+5. **Ignore markers, after rebasing.** Markers landed on main while this was
+   being written, and they take a declaration out of everything a dependent can
+   read. So the surface carries each member's marker: whether it hides right
+   now, and the conditions it hides on. Without that, adding `#[Ignore]` to a
+   property left the surface where it was and dependents kept output for a
+   member that had just been hidden.
+
+   Recording the conditions as well as the answer is deliberate. Whether a
+   condition holds is decided when the marker is read, not when the file was
+   analyzed, so a run whose conditions answer differently sees different
+   surfaces and re-analyzes. That does not make the cache aware of config
+   changes on its own, since an unchanged file is never re-read, but it stops a
+   marker change from passing unnoticed.
+
+6. **What is left.**
 
    `StateTracker` is serialised into every cache entry. It holds the variable
    state of the run that produced the entry, nothing reads it back, and it is

--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -142,10 +142,25 @@ determinism still clean, all tests pass.
    analyzed first, one that a cycle member is answered against the finished
    analysis of the other member. Each fails without the change it covers.
 
-2. **Fingerprint invalidation.** Store **direct** dependencies only, each keyed
-   by that dependency's public surface hash rather than its modification time or
-   its bytes. A body edit changes the file's own hash so that file is
-   re-analysed, its surface is unchanged, so its dependents stay valid.
+2. **Fingerprint invalidation.** Done, in three slices. Store **direct**
+   dependencies only, each keyed by that dependency's public surface hash rather
+   than its modification time or its bytes. A body edit changes the file's own
+   hash so that file is re-analysed, its surface is unchanged, so its dependents
+   stay valid.
+
+   | touched | rewritten before | rewritten now | time before | time now |
+   |---|---|---|---|---|
+   | `Instance.php` | 258 | 61 | 3.7s | 2.0s |
+   | `User.php` | 1,370 | 147 | 11.2s | 2.0s |
+   | `Environment.php` | 1,366 | 230 | 16.9s | 2.7s |
+   | `Organization.php` | 1,370 | 319 | 19.5s | 2.9s |
+
+   Cold and warm are unchanged, 17.5s to 19.1s and 1.2s to 1.35s. The cache went
+   from 290MB to 62MB. Touching a file without editing it rewrites 3 entries
+   where it used to rewrite 1,366.
+
+   All seven shapes in `shapesweep.sh` agree between warm and cold, including a
+   new body-only edit shape that exists to test exactly what this bets on.
 
    Measured ceiling, on a settled cache:
 
@@ -164,15 +179,13 @@ determinism still clean, all tests pass.
    Cache size falls out of this for free. Of 272MB, 85% is dependency
    bookkeeping: 1.6M path and mtime pairs. Dependencies **recorded** per entry:
    median 92, mean 489, max 1,803. Dependencies **actually used**: median 2,
-   mean 4, max 63. The closure is 129 times the direct edges, so direct edges
-   take the cache to roughly 42MB.
+   mean 4, max 63. The closure is 129 times the direct edges. The estimate from
+   that was roughly 42MB; it came out at 62MB, 12MB of which is the records
+   taking a filesystem block each.
 
-   Note why the closure is there: the comment in `AnalyzedCache` says it is
-   stored flat so an entry can be validated by stat'ing a list without walking
-   the graph. Direct edges break that unless validity is decided by the
-   dependency's surface hash, which keeps the check one level deep. That needs a
-   small side index of path to surface hash so a dependency can be checked
-   without loading its whole entry.
+   The closure was there so an entry could be validated by stat'ing a flat list
+   without walking the graph. Nothing replaces that: the walk came back, over
+   records rather than entries. See the slice 3 note below.
 
    **Slice 1 is done.** `Analyzer\Surface` is the one definition of what a
    dependent can see, `surfacedump.php` calls it rather than keeping its own
@@ -192,7 +205,7 @@ determinism still clean, all tests pass.
    nullable, so asking a class in the global namespace for its namespace was a
    fatal error. Fixed on the way past.
 
-   **Slice 2 is done.** Every persisted entry now has a `<md5>.surface` file
+   **Slice 2 is done, and slice 3 replaced its file format.** Every persisted entry now has a `<md5>.surface` file
    beside it holding its surface hash, so a dependency can be checked with one
    small read instead of unserializing its entry. `AnalyzedCache::surfaceHash()`
    answers from memory, then that file, then by hashing an entry already in
@@ -200,11 +213,31 @@ determinism still clean, all tests pass.
 
    It costs nothing in time: cold 18.5s against 18.6s for the same tree without
    it, warm and edit unchanged. On disk the 3,149 files hold 100KB of hashes and
-   occupy 12MB, all of it filesystem block overhead. That is noise against
-   today's 278MB and about a quarter of what the cache should weigh after slice
-   3, so if it starts to look expensive the answer is one index file rather than
-   3,149 small ones. Kept as files for now: they are written and deleted with
-   the entry they describe, so there is no index to keep in step or repair.
+   occupy 12MB, all of it filesystem block overhead.
+
+   **Slice 3 is done, and it corrected the plan above.** Direct edges cannot be
+   validated by stat'ing them. With the closure gone, a dependency whose own
+   bytes are untouched can still have moved, because something under *it*
+   changed. Validity has to walk, so the file beside each entry holds the edges
+   as well as the hash: the entry's own time and surface, and every file it
+   reached with the surface that file showed. It is a `.record` now, not a
+   `.surface`, and the entry itself no longer carries a dependency list at all,
+   which is where the 62MB comes from.
+
+   Deciding whether an entry holds reads records, never entries: the file is
+   unchanged and every file it reached is unchanged, or one of them changed and
+   has to be analyzed to find out whether the change reached its surface. Each
+   answer is worked out once per run and remembered. A file with no record of
+   its own has nothing underneath it, so its bytes are the whole answer. Cycles
+   in the recorded graph are handled by counting a path as holding while it is
+   being decided; every member is checked on its own terms anyway.
+
+   Analyzing a changed dependency mid-check needs the analyzer, which the cache
+   has no business knowing about, so the analyzer hands it a closure on
+   construction. One consequence worth remembering: an analysis started from
+   inside a validity check records itself against whatever frame is open, which
+   over-records an edge that is real but indirect. That can only cause extra
+   invalidation, never stale output.
 
 3. **Loose ends, any time.** A regression test for the `Type::union` fix. It
    needs a shared type object reachable from two places, which no current test

--- a/benchmarks/cache/determinism.sh
+++ b/benchmarks/cache/determinism.sh
@@ -6,12 +6,14 @@
 # source analysed twice, two answers.
 #
 # Usage: determinism.sh <label> [target-relative-path]
+#
+# Runs against the Cloud checkout unless SURVEYOR_BENCH_APP points elsewhere.
 
 set -u
 
 S="$(cd "$(dirname "$0")" && pwd)"
 SUR=/Users/joetannenbaum/Dev/surveyor
-APP=/Users/joetannenbaum/Herd/cloud
+APP=${SURVEYOR_BENCH_APP:-/Users/joetannenbaum/Herd/cloud}
 LABEL=$1
 TARGET=${2:-app/Models/User.php}
 
@@ -21,14 +23,19 @@ KEEP=$S/dt-$LABEL
 cd "$APP" || exit 1
 
 # Nothing here edits app source, it only touches a file, so a dirty tree is
-# reported rather than treated as fatal.
-if ! git diff --quiet; then
+# reported rather than treated as fatal. The app need not be a repository at all.
+if git rev-parse --git-dir > /dev/null 2>&1 && ! git diff --quiet; then
   echo "note: cloud has modified tracked files:"
   git diff --name-only | sed 's/^/  /'
 fi
 
 # The app loads Surveyor from vendor, so the working tree has to be copied in.
-rsync -a --delete "$SUR/src/" "$APP/vendor/laravel/surveyor/src/"
+# Some checkouts symlink the package straight at a working copy, in which case
+# there is nothing to copy and copying would mean writing a directory onto
+# itself.
+if [ "$(cd "$SUR/src" && pwd -P)" != "$(cd "$APP/vendor/laravel/surveyor/src" && pwd -P)" ]; then
+  rsync -a --delete "$SUR/src/" "$APP/vendor/laravel/surveyor/src/"
+fi
 
 rm -rf "$KEEP"; mkdir -p "$KEEP"
 rm -rf "$CACHE"; mkdir -p "$CACHE"

--- a/benchmarks/cache/mutate.py
+++ b/benchmarks/cache/mutate.py
@@ -1,25 +1,62 @@
-"""Applies one named source mutation to the Cloud checkout.
+"""Applies one named source mutation to an application checkout.
 
 Usage: mutate.py <shape> <phase>
 
 Phases: `pre` runs before the base cache is built, `apply` is the change under
 test. Most shapes only use `apply`; the removal and rename shapes need the file
 to exist in the base build first.
+
+Which application, and which files inside it to touch, comes from the
+environment: SURVEYOR_BENCH_APP for the checkout and SURVEYOR_BENCH_PRESET for
+the set of targets. Every shape has to change generated output, or it proves
+nothing, which is why the targets are named per application rather than guessed.
 """
 
 import os
 import re
 import sys
 
-APP = "/Users/joetannenbaum/Herd/cloud"
-INSTANCE = f"{APP}/app/Models/Instance.php"
-ENUM = f"{APP}/app/Enums/InstanceType.php"
-PROBE = f"{APP}/app/Enums/SweepProbeEnum.php"
-PROBE_RENAMED = f"{APP}/app/Enums/SweepProbeRenamed.php"
+APP = os.environ.get("SURVEYOR_BENCH_APP", "/Users/joetannenbaum/Herd/cloud")
+
+PRESETS = {
+    "cloud": {
+        "model": "app/Models/Instance.php",
+        "relation": "\n    public function sweepProbeRelation(): HasOne\n    {\n        return $this->hasOne(Daemon::class);\n    }\n",
+        "remove_method": "activeScheduledAutoscaleOverride",
+        "enum": "app/Enums/InstanceType.php",
+        "enum_case": ("MANAGED_QUEUE = 'managed_queue'", "MANAGED_QUEUE = 'managed_queue_probe'"),
+        "body": (
+            "return $this->identifier;",
+            "$identifier = $this->identifier;\n\n        return $identifier;",
+        ),
+        "probe_namespace": "App\\Enums",
+        "probe_dir": "app/Enums",
+    },
+    "forge": {
+        "model": "app/Models/Server.php",
+        "relation": "\n    public function sweepProbeRelation(): HasOne\n    {\n        return $this->hasOne(ServerActivation::class);\n    }\n",
+        "remove_method": "activation",
+        "enum": "app/Enums/ServerType.php",
+        "enum_case": ("case Cache = 'cache'", "case Cache = 'cache_probe'"),
+        "body": (
+            "return $this->hasOne(ServerActivation::class);",
+            "$activation = $this->hasOne(ServerActivation::class);\n\n        return $activation;",
+        ),
+        "probe_namespace": "App\\Enums",
+        "probe_dir": "app/Enums",
+    },
+}
+
+preset = PRESETS[os.environ.get("SURVEYOR_BENCH_PRESET", "cloud")]
+
+MODEL = f"{APP}/{preset['model']}"
+ENUM = f"{APP}/{preset['enum']}"
+PROBE = f"{APP}/{preset['probe_dir']}/SweepProbeEnum.php"
+PROBE_RENAMED = f"{APP}/{preset['probe_dir']}/SweepProbeRenamed.php"
 
 PROBE_BODY = """<?php
 
-namespace App\\Enums;
+namespace {namespace};
 
 enum {name}: string
 {{
@@ -40,24 +77,20 @@ def write(p, s):
 
 
 def append_method():
-    s = read(INSTANCE)
+    s = read(MODEL)
     i = s.rstrip().rfind("\n}")
-    probe = (
-        "\n    public function sweepProbeRelation(): HasOne\n"
-        "    {\n        return $this->hasOne(Daemon::class);\n    }\n"
-    )
-    write(INSTANCE, s[:i] + probe + s[i:])
+    write(MODEL, s[:i] + preset["relation"] + s[i:])
 
 
 def remove_method(name):
-    s = read(INSTANCE)
+    s = read(MODEL)
     m = re.search(rf"\n    public function {name}\(", s)
     if not m:
-        sys.exit(f"method {name} not found")
-    # Method bodies in this file are brace-balanced and indented four spaces,
+        sys.exit(f"method {name} not found in {MODEL}")
+    # Method bodies in these files are brace-balanced and indented four spaces,
     # so the first `\n    }` after the signature closes it.
     end = s.index("\n    }", m.start()) + len("\n    }")
-    write(INSTANCE, s[: m.start()] + s[end:])
+    write(MODEL, s[: m.start()] + s[end:])
 
 
 def edit_body():
@@ -66,24 +99,23 @@ def edit_body():
     The point of surface fingerprints is that this invalidates the file itself
     and nothing else, so warm output has to match cold anyway.
     """
-    s = read(INSTANCE)
-    if "return $this->identifier;" not in s:
-        sys.exit("body to rewrite not found")
-    write(INSTANCE, s.replace(
-        "return $this->identifier;",
-        "$identifier = $this->identifier;\n\n        return $identifier;",
-    ))
+    s = read(MODEL)
+    find, replace = preset["body"]
+    if find not in s:
+        sys.exit(f"body to rewrite not found in {MODEL}")
+    write(MODEL, s.replace(find, replace))
 
 
 def edit_enum_case():
     s = read(ENUM)
-    if "MANAGED_QUEUE = 'managed_queue'" not in s:
-        sys.exit("enum case not found")
-    write(ENUM, s.replace("MANAGED_QUEUE = 'managed_queue'", "MANAGED_QUEUE = 'managed_queue_probe'"))
+    find, replace = preset["enum_case"]
+    if find not in s:
+        sys.exit(f"enum case not found in {ENUM}")
+    write(ENUM, s.replace(find, replace))
 
 
 def add_probe(path, name):
-    write(path, PROBE_BODY.format(name=name))
+    write(path, PROBE_BODY.format(namespace=preset["probe_namespace"], name=name))
 
 
 def remove(path):
@@ -91,9 +123,14 @@ def remove(path):
         os.unlink(path)
 
 
+def print_targets():
+    print(preset["model"], preset["enum"])
+
+
 actions = {
+    ("targets", "list"): print_targets,
     ("append-method", "apply"): append_method,
-    ("remove-method", "apply"): lambda: remove_method("activeScheduledAutoscaleOverride"),
+    ("remove-method", "apply"): lambda: remove_method(preset["remove_method"]),
     ("edit-body", "apply"): edit_body,
     ("edit-enum-case", "apply"): edit_enum_case,
     ("add-file", "apply"): lambda: add_probe(PROBE, "SweepProbeEnum"),

--- a/benchmarks/cache/mutate.py
+++ b/benchmarks/cache/mutate.py
@@ -60,6 +60,21 @@ def remove_method(name):
     write(INSTANCE, s[: m.start()] + s[end:])
 
 
+def edit_body():
+    """Rewrite a method body without changing anything a dependent can see.
+
+    The point of surface fingerprints is that this invalidates the file itself
+    and nothing else, so warm output has to match cold anyway.
+    """
+    s = read(INSTANCE)
+    if "return $this->identifier;" not in s:
+        sys.exit("body to rewrite not found")
+    write(INSTANCE, s.replace(
+        "return $this->identifier;",
+        "$identifier = $this->identifier;\n\n        return $identifier;",
+    ))
+
+
 def edit_enum_case():
     s = read(ENUM)
     if "MANAGED_QUEUE = 'managed_queue'" not in s:
@@ -79,6 +94,7 @@ def remove(path):
 actions = {
     ("append-method", "apply"): append_method,
     ("remove-method", "apply"): lambda: remove_method("activeScheduledAutoscaleOverride"),
+    ("edit-body", "apply"): edit_body,
     ("edit-enum-case", "apply"): edit_enum_case,
     ("add-file", "apply"): lambda: add_probe(PROBE, "SweepProbeEnum"),
     ("remove-file", "pre"): lambda: add_probe(PROBE, "SweepProbeEnum"),

--- a/benchmarks/cache/shapesweep.sh
+++ b/benchmarks/cache/shapesweep.sh
@@ -6,11 +6,14 @@
 # editing in place, adding a file, deleting a file, renaming a file.
 #
 # Usage: shapesweep.sh <label>
+#
+# Runs against the Cloud checkout unless SURVEYOR_BENCH_APP points elsewhere,
+# with SURVEYOR_BENCH_PRESET naming the set of files to edit.
 
 set -u
 
 S="$(cd "$(dirname "$0")" && pwd)"
-APP=/Users/joetannenbaum/Herd/cloud
+APP=${SURVEYOR_BENCH_APP:-/Users/joetannenbaum/Herd/cloud}
 LABEL=$1
 KEEP=$S/sh-$LABEL
 CACHE_W=$S/sh-cache-w
@@ -22,7 +25,7 @@ cd "$APP" || exit 1
 
 # The shapes edit two tracked files. Both are copied first and restored from
 # those copies, so uncommitted work elsewhere in the app is left alone.
-MUTATED=(app/Models/Instance.php app/Enums/InstanceType.php)
+MUTATED=($(python3 "$S/mutate.py" targets list))
 ORIGINALS=$S/sh-$LABEL-originals
 rm -rf "$ORIGINALS"; mkdir -p "$ORIGINALS"
 

--- a/benchmarks/cache/shapesweep.sh
+++ b/benchmarks/cache/shapesweep.sh
@@ -16,7 +16,7 @@ KEEP=$S/sh-$LABEL
 CACHE_W=$S/sh-cache-w
 CACHE_C=$S/sh-cache-c
 
-SHAPES=(append-method remove-method edit-enum-case add-file remove-file rename-file)
+SHAPES=(append-method remove-method edit-body edit-enum-case add-file remove-file rename-file)
 
 cd "$APP" || exit 1
 
@@ -81,7 +81,16 @@ for shape in "${SHAPES[@]}"; do
   moved=$(diff "$KEEP/$shape.base" "$KEEP/$shape.cold" | grep -c '^[<>]')
 
   effect="changed $moved lines"
-  [ "$moved" -eq 0 ] && effect="NO EFFECT ON OUTPUT (vacuous test)"
+
+  if [ "$moved" -eq 0 ]; then
+    # A body edit is meant to leave the output alone. Anywhere else, no change
+    # means the shape tested nothing.
+    if [ "$shape" = "edit-body" ]; then
+      effect="no output change, as intended"
+    else
+      effect="NO EFFECT ON OUTPUT (vacuous test)"
+    fi
+  fi
 
   printf '%-16s %14s %8s %s\n' "$shape" "$sorted" "$raw" "$effect"
 

--- a/benchmarks/cache/surfacedump.php
+++ b/benchmarks/cache/surfacedump.php
@@ -9,13 +9,14 @@
  * Without --detail: one `path<TAB>surface-hash<TAB>entry-hash` row per entry.
  * With --detail: the canonical surface lines themselves, prefixed by path.
  *
+ * What counts as a surface is Surveyor's own `Analyzer\Surface`, so this script
+ * and the cache cannot disagree about it.
+ *
  * The autoloader defaults to the Cloud checkout; override with SURFACE_AUTOLOAD.
  */
 
 use Laravel\Surveyor\Analysis\Scope;
-use Laravel\Surveyor\Analyzed\ClassLikeResult;
-use Laravel\Surveyor\Analyzed\MethodResult;
-use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
+use Laravel\Surveyor\Analyzer\Surface;
 
 require getenv('SURFACE_AUTOLOAD') ?: '/Users/joetannenbaum/Herd/cloud/vendor/autoload.php';
 
@@ -27,6 +28,26 @@ $detail = in_array('--detail', $argv, true);
 // Hashes each top-level Scope property on its own, so a diff says which part
 // of an entry moved rather than only that it moved.
 $fields = in_array('--fields', $argv, true);
+
+/**
+ * Hashes each top-level Scope property on its own. This is a diagnostic, not a
+ * surface: it says which part of an entry moved, including the parts a
+ * dependent cannot see.
+ *
+ * @return list<string>
+ */
+function fieldLines(Scope $scope): array
+{
+    $lines = [];
+
+    foreach ((new ReflectionObject($scope))->getProperties() as $property) {
+        $lines[] = 'field '.$property->getName().' '.($property->isInitialized($scope)
+            ? md5(serialize($property->getValue($scope)))
+            : '<uninitialized>');
+    }
+
+    return $lines;
+}
 
 function peek(object $object, string $property)
 {
@@ -45,173 +66,6 @@ function peek(object $object, string $property)
     return $prop->isInitialized($object) ? $prop->getValue($object) : null;
 }
 
-function typeId(?TypeContract $type): string
-{
-    if ($type === null) {
-        return '-';
-    }
-
-    try {
-        $id = $type->id();
-    } catch (Throwable $e) {
-        $id = 'ERR:'.$e->getMessage();
-    }
-
-    return $type::class.'('.$id.')'
-        .($type->isNullable() ? '|null' : '')
-        .($type->isOptional() ? '|opt' : '');
-}
-
-function methodLines(string $prefix, MethodResult $method): array
-{
-    $lines = [];
-
-    $parameters = [];
-
-    foreach (peek($method, 'parameters') ?? [] as $name => $type) {
-        $parameters[] = $name.':'.typeId($type);
-    }
-
-    $returns = [];
-
-    foreach (peek($method, 'returnTypes') ?? [] as $entry) {
-        $returns[] = typeId($entry['type']);
-    }
-
-    $lines[] = $prefix.' ('.implode(', ', $parameters).') -> '.implode(' + ', $returns)
-        .($method->isModelRelation() ? ' [relation]' : '');
-
-    foreach (peek($method, 'validationRules') ?? [] as $key => $rules) {
-        $lines[] = $prefix.' rule '.$key.' = '.json_encode($rules);
-    }
-
-    return $lines;
-}
-
-/**
- * Everything a dependent can read off a cached entry, other than the state
- * tracker, which holds the variables of the run that produced it.
- */
-function scopeLines(Scope $scope): array
-{
-    $lines = [
-        'scope entity '.($scope->entityName() ?? '-'),
-        'scope method '.($scope->methodName() ?? '-'),
-        'scope namespace '.(peek($scope, 'namespace') ?? '-'),
-        'scope extends '.implode(',', peek($scope, 'extends') ?? []),
-        'scope implements '.implode(',', peek($scope, 'implements') ?? []),
-        'scope traits '.implode(',', peek($scope, 'traits') ?? []),
-    ];
-
-    foreach (peek($scope, 'uses') ?? [] as $alias => $use) {
-        $lines[] = 'scope use '.$alias.' = '.$use;
-    }
-
-    foreach (peek($scope, 'constants') ?? [] as $name => $type) {
-        $lines[] = 'scope constant '.$name.' '.(is_object($type) ? typeId($type) : json_encode($type));
-    }
-
-    foreach (peek($scope, 'cases') ?? [] as $name => $case) {
-        $lines[] = 'scope case '.$name.' '.(is_object($case) ? typeId($case) : json_encode($case));
-    }
-
-    foreach (peek($scope, 'parameters') ?? [] as $name => $type) {
-        $lines[] = 'scope parameter '.$name.' '.typeId($type);
-    }
-
-    foreach (peek($scope, 'returnTypes') ?? [] as $index => $type) {
-        $lines[] = 'scope return '.$index.' '.(is_object($type) ? typeId($type) : json_encode($type));
-    }
-
-    foreach (peek($scope, 'macros') ?? [] as $class => $macros) {
-        foreach ($macros as $name => $type) {
-            $lines[] = 'scope macro '.$class.'::'.$name.' '.typeId($type);
-        }
-    }
-
-    foreach (peek($scope, 'validationRules') ?? [] as $key => $rules) {
-        $lines[] = 'scope rule '.$key.' = '.json_encode($rules);
-    }
-
-    foreach (peek($scope, 'templateTags') ?? [] as $index => $tag) {
-        $lines[] = 'scope template '.$index.' '.(is_object($tag) && $tag instanceof TypeContract ? typeId($tag) : get_debug_type($tag));
-    }
-
-    $receiver = peek($scope, 'receiverType');
-
-    if ($receiver !== null) {
-        $lines[] = 'scope receiver '.typeId($receiver);
-    }
-
-    return $lines;
-}
-
-function fieldLines(Scope $scope): array
-{
-    $lines = [];
-
-    foreach ((new ReflectionObject($scope))->getProperties() as $property) {
-        if (! $property->isInitialized($scope)) {
-            $lines[] = 'field '.$property->getName().' <uninitialized>';
-
-            continue;
-        }
-
-        $value = $property->getValue($scope);
-
-        $lines[] = 'field '.$property->getName().' '.md5(serialize($value));
-    }
-
-    return $lines;
-}
-
-function surfaceLines(Scope $scope): array
-{
-    $result = $scope->result();
-
-    if ($result === null) {
-        return [...scopeLines($scope), '(no result)'];
-    }
-
-    if ($result instanceof MethodResult) {
-        return [...scopeLines($scope), ...methodLines('method '.$result->name(), $result)];
-    }
-
-    /** @var ClassLikeResult $result */
-    $lines = [
-        ...scopeLines($scope),
-        'class '.$result->name(),
-        'namespace '.(peek($result, 'namespace') ?? '-'),
-        'entity '.$result->entityType()->value,
-        'extends '.implode(',', $result->extends()),
-        'implements '.implode(',', $result->implements()),
-        'traits '.implode(',', peek($result, 'traits') ?? []),
-        'arrayable '.var_export($result->isArrayable(), true),
-    ];
-
-    foreach (peek($result, 'methods') ?? [] as $name => $method) {
-        $lines = [...$lines, ...methodLines('method '.$name, $method)];
-    }
-
-    foreach (peek($result, 'properties') ?? [] as $name => $property) {
-        $lines[] = 'property '.$name.' '.$property->visibility.' '.typeId($property->type)
-            .' doc='.var_export($property->fromDocBlock, true)
-            .' attr='.var_export($property->modelAttribute, true)
-            .' rel='.var_export($property->modelRelation, true)
-            .' ro='.var_export($property->readOnly, true)
-            .' wo='.var_export($property->writeOnly, true);
-    }
-
-    foreach (peek($result, 'constants') ?? [] as $name => $constant) {
-        $lines[] = 'constant '.$name.' '.typeId($constant->type);
-    }
-
-    sort($lines);
-
-    return $lines;
-}
-
-// Ranger keeps its structure index alongside the analysis entries.
 $files = array_values(array_filter(
     glob(rtrim($dir, '/').'/*.cache'),
     fn ($file) => ! str_starts_with(basename($file), 'inventory-'),
@@ -243,10 +97,10 @@ foreach ($files as $file) {
 
     $scope = $data['scope'];
     $path = peek($scope, 'path') ?? basename($file);
-    $lines = $fields ? fieldLines($scope) : surfaceLines($scope);
+    $lines = $fields ? fieldLines($scope) : Surface::lines($scope);
 
     $rows[$path] = [
-        'surface' => md5(implode("\n", $lines)),
+        'surface' => $fields ? md5(implode("\n", $lines)) : Surface::hash($scope),
         'entry' => md5(serialize($scope)),
         'lines' => $lines,
         'dependencies' => count($data['dependencies'] ?? []),

--- a/benchmarks/cache/timeit.sh
+++ b/benchmarks/cache/timeit.sh
@@ -11,14 +11,19 @@
 set -u
 
 S="$(cd "$(dirname "$0")" && pwd)"
-APP=/Users/joetannenbaum/Herd/cloud
+APP=${SURVEYOR_BENCH_APP:-/Users/joetannenbaum/Herd/cloud}
 LABEL=$1
 SRC=${2:-/Users/joetannenbaum/Dev/surveyor/src}
 RUNS=${3:-2}
 TARGET=$APP/${4:-app/Models/Instance.php}
 BACKUP=$S/tm-$LABEL-$(basename "${4:-Instance.php}").orig
 
-rsync -a --delete "$SRC/" "$APP/vendor/laravel/surveyor/src/"
+# Some checkouts symlink the package straight at a working copy, in which case
+# there is nothing to copy and copying would mean writing a directory onto
+# itself.
+if [ "$(cd "$SRC" && pwd -P)" != "$(cd "$APP/vendor/laravel/surveyor/src" && pwd -P)" ]; then
+  rsync -a --delete "$SRC/" "$APP/vendor/laravel/surveyor/src/"
+fi
 cp "$TARGET" "$BACKUP"
 trap 'cp "$BACKUP" "$TARGET"' EXIT
 

--- a/src/Analyzed/ClassLikeResult.php
+++ b/src/Analyzed/ClassLikeResult.php
@@ -68,7 +68,7 @@ class ClassLikeResult
         return $this->name;
     }
 
-    public function namespace(): string
+    public function namespace(): ?string
     {
         return $this->namespace;
     }
@@ -211,6 +211,14 @@ class ClassLikeResult
         $this->properties[$property->name] = $property;
     }
 
+    /**
+     * @return array<string, PropertyResult>
+     */
+    public function properties(): array
+    {
+        return $this->properties;
+    }
+
     public function hasConstant(string $name): bool
     {
         return isset($this->constants[$name]);
@@ -224,6 +232,14 @@ class ClassLikeResult
     public function addConstant(ConstantResult $constant): void
     {
         $this->constants[$constant->name] = $constant;
+    }
+
+    /**
+     * @return array<string, ConstantResult>
+     */
+    public function constants(): array
+    {
+        return $this->constants;
     }
 
     public function hasUse(string $name): bool

--- a/src/Analyzed/ClassLikeResult.php
+++ b/src/Analyzed/ClassLikeResult.php
@@ -212,6 +212,19 @@ class ClassLikeResult
     }
 
     /**
+     * Every method, including the ones marked to be left out. Callers acting on
+     * a result want publicMethods(); this is for describing one.
+     *
+     * @return array<string, MethodResult>
+     */
+    public function methods(): array
+    {
+        return $this->methods;
+    }
+
+    /**
+     * Every property, including the ones marked to be left out.
+     *
      * @return array<string, PropertyResult>
      */
     public function properties(): array

--- a/src/Analyzer/AnalyzedCache.php
+++ b/src/Analyzer/AnalyzedCache.php
@@ -15,7 +15,7 @@ class AnalyzedCache
      * class changes, so an upgrade reads its own entries and not ones left by
      * a version whose objects no longer unserialize cleanly.
      */
-    public const SCHEMA = 4;
+    public const SCHEMA = 5;
 
     protected static array $cached = [];
 
@@ -104,7 +104,7 @@ class AnalyzedCache
      * enough to read while deciding whether the entry still holds, which is
      * the point of keeping it out of the entry itself.
      *
-     * @var array<string, array{mtime: int, surface: string, dependencies: list<array{path: string, mtime: int, surface: string|null}>}|false>
+     * @var array<string, array{schema: int, mtime: int, surface: string, dependencies: list<array{path: string, mtime: int, surface: string|null}>}|false>
      */
     protected static array $records = [];
 
@@ -730,6 +730,7 @@ class AnalyzedCache
         }
 
         static::$records[$path] = [
+            'schema' => static::SCHEMA,
             'mtime' => $mtime,
             'surface' => static::$surfaces[$path],
             'dependencies' => $recorded,
@@ -744,7 +745,7 @@ class AnalyzedCache
     }
 
     /**
-     * @return array{mtime: int, surface: string, dependencies: list<array{path: string, mtime: int, surface: string|null}>}|null
+     * @return array{schema: int, mtime: int, surface: string, dependencies: list<array{path: string, mtime: int, surface: string|null}>}|null
      */
     protected static function readRecord(string $path): ?array
     {
@@ -772,7 +773,10 @@ class AnalyzedCache
             $record = null;
         }
 
-        if (! is_array($record) || ! isset($record['mtime'], $record['surface'], $record['dependencies'])) {
+        if (! is_array($record)
+            || ($record['schema'] ?? null) !== static::SCHEMA
+            || ! isset($record['mtime'], $record['surface'], $record['dependencies'])
+        ) {
             static::$records[$path] = false;
 
             return null;

--- a/src/Analyzer/AnalyzedCache.php
+++ b/src/Analyzer/AnalyzedCache.php
@@ -72,6 +72,14 @@ class AnalyzedCache
     /** @var array<string, int|null> */
     protected static array $modifiedTimes = [];
 
+    /**
+     * The surface hash of each entry seen this run, whether it was analyzed or
+     * read back from disk.
+     *
+     * @var array<string, string>
+     */
+    protected static array $surfaces = [];
+
     protected static bool $fileTimesFrozen = false;
 
     protected static ?string $key = null;
@@ -308,6 +316,30 @@ class AnalyzedCache
         }
     }
 
+    /**
+     * The hash of what dependents can see of a path, without unserializing its
+     * entry. An analyzed entry answers from memory; anything else is read from
+     * the small file written alongside the entry.
+     */
+    public static function surfaceHash(string $path): ?string
+    {
+        if (isset(static::$surfaces[$path])) {
+            return static::$surfaces[$path];
+        }
+
+        // Reading the small file beats hashing an entry that was loaded from
+        // disk, which is why it is written in the first place.
+        if (static::$persistToDisk && file_exists($surfaceFile = static::getSurfaceFilePath($path))) {
+            return static::$surfaces[$path] = file_get_contents($surfaceFile);
+        }
+
+        if (isset(static::$cached[$path])) {
+            return static::$surfaces[$path] = Surface::hash(static::$cached[$path]);
+        }
+
+        return null;
+    }
+
     public static function get(string $path): ?Scope
     {
         $currentModifiedTime = static::modifiedTime($path);
@@ -437,12 +469,13 @@ class AnalyzedCache
 
     public static function invalidate(string $path): void
     {
-        unset(static::$cached[$path], static::$fileTimes[$path]);
+        unset(static::$cached[$path], static::$fileTimes[$path], static::$surfaces[$path]);
 
         if (static::$persistToDisk) {
-            $cacheFile = static::getCacheFilePath($path);
-            if (file_exists($cacheFile)) {
-                unlink($cacheFile);
+            foreach ([static::getCacheFilePath($path), static::getSurfaceFilePath($path)] as $file) {
+                if (file_exists($file)) {
+                    unlink($file);
+                }
             }
         }
     }
@@ -460,6 +493,7 @@ class AnalyzedCache
         static::$deferred = [];
         static::$settled = [];
         static::$modifiedTimes = [];
+        static::$surfaces = [];
     }
 
     public static function clear(): void
@@ -467,7 +501,11 @@ class AnalyzedCache
         static::clearMemory();
 
         if (static::$cacheDirectory && is_dir(static::$cacheDirectory)) {
-            $files = glob(static::$cacheDirectory.'/*.cache');
+            $files = [
+                ...glob(static::$cacheDirectory.'/*.cache'),
+                ...glob(static::$cacheDirectory.'/*.surface'),
+            ];
+
             foreach ($files as $file) {
                 unlink($file);
             }
@@ -531,10 +569,19 @@ class AnalyzedCache
         }
 
         file_put_contents($cacheFile, $serialized);
+
+        static::$surfaces[$path] = $surface = Surface::hash($analyzed);
+
+        file_put_contents(static::getSurfaceFilePath($path), $surface);
     }
 
     protected static function getCacheFilePath(string $path): string
     {
         return static::$cacheDirectory.'/'.md5($path).'.cache';
+    }
+
+    protected static function getSurfaceFilePath(string $path): string
+    {
+        return static::$cacheDirectory.'/'.md5($path).'.surface';
     }
 }

--- a/src/Analyzer/AnalyzedCache.php
+++ b/src/Analyzer/AnalyzedCache.php
@@ -80,6 +80,31 @@ class AnalyzedCache
      */
     protected static array $surfaces = [];
 
+    /**
+     * How to find out what a file's surface is now. Analyzing it is the only
+     * way, and only the analyzer can do that, so it hands this in.
+     *
+     * @var (callable(string): ?string)|null
+     */
+    protected static $surfaceResolver = null;
+
+    /**
+     * The record written beside each entry: its own time and surface, and the
+     * files it reached with the surface each of them had at the time. Small
+     * enough to read while deciding whether the entry still holds, which is
+     * the point of keeping it out of the entry itself.
+     *
+     * @var array<string, array{mtime: int, surface: string, dependencies: list<array{path: string, mtime: int, surface: string|null}>}|false>
+     */
+    protected static array $records = [];
+
+    /**
+     * Whether each path's entry still holds, worked out once per run.
+     *
+     * @var array<string, bool>
+     */
+    protected static array $current = [];
+
     protected static bool $fileTimesFrozen = false;
 
     protected static ?string $key = null;
@@ -90,8 +115,12 @@ class AnalyzedCache
     }
 
     /**
-     * Record that the analysis in progress depends on the given path, along
-     * with everything that path itself depends on.
+     * Record that the analysis in progress reached the given path.
+     *
+     * Only the files a file reaches itself are recorded. What those files
+     * reached in turn is their own business: an entry is validated against the
+     * surface of each file it names, and a change further down the graph only
+     * matters here if it moved one of those surfaces.
      */
     public static function addDependency(string $path): void
     {
@@ -99,15 +128,7 @@ class AnalyzedCache
             return;
         }
 
-        $frame = array_key_last(static::$frames);
-
-        static::$frames[$frame][$path] = true;
-
-        // A path resolved from cache is never pushed as a frame of its own, so
-        // its dependencies have to be folded in here or they are lost.
-        if (isset(static::$dependencies[$path])) {
-            static::$frames[$frame] += static::$dependencies[$path];
-        }
+        static::$frames[array_key_last(static::$frames)][$path] = true;
     }
 
     public static function beginAnalysis(string $path): void
@@ -146,8 +167,7 @@ class AnalyzedCache
     }
 
     /**
-     * Close the analysis of a path, keep its dependency closure, and fold that
-     * closure into the analysis that asked for it.
+     * Close the analysis of a path and keep the files it reached.
      */
     public static function endAnalysis(string $path): void
     {
@@ -165,48 +185,41 @@ class AnalyzedCache
 
         static::$dependencies[$path] = $dependencies;
 
-        if (static::$frames !== []) {
-            $frame = array_key_last(static::$frames);
-            static::$frames[$frame] += $dependencies;
-
-            if ($tainted) {
-                static::$frameTainted[$frame] = true;
-            }
+        // The caller already recorded this path when it asked for it, and it
+        // does not inherit what this path reached.
+        if ($tainted && static::$frames !== []) {
+            static::$frameTainted[array_key_last(static::$frameTainted)] = true;
         }
 
         if ($index === static::$cycleFloor) {
             static::$cycleFloor = null;
-            static::flushDeferred($dependencies, $path);
+            static::flushDeferred();
         }
     }
 
     /**
-     * Write out the entries held back while a cycle was open. Every member of
-     * the cycle gets the closure of its outermost file plus every other member,
-     * since a change to any of them could change all of them.
+     * Write out the entries held back while a cycle was open.
      *
-     * @param  array<string, true>  $dependencies
+     * Each of them reached a file that was still being analyzed, so each is
+     * listed for another look once the cycle has closed. Their own edges are
+     * complete: a file is recorded as reached before the analysis discovers it
+     * cannot be finished.
      */
-    protected static function flushDeferred(array $dependencies, string $root): void
+    protected static function flushDeferred(): void
     {
         $deferred = static::$deferred;
         static::$deferred = [];
 
-        $dependencies[$root] = true;
-
         foreach ($deferred as $entry) {
-            $dependencies[$entry['path']] = true;
-        }
-
-        foreach ($deferred as $entry) {
-            $own = $dependencies;
-            unset($own[$entry['path']]);
-
-            static::$dependencies[$entry['path']] = $own;
             static::$settled[] = $entry['path'];
 
             if (static::$persistToDisk) {
-                static::persistToDisk($entry['path'], $entry['scope'], $entry['mtime'], $own);
+                static::persistToDisk(
+                    $entry['path'],
+                    $entry['scope'],
+                    $entry['mtime'],
+                    static::$dependencies[$entry['path']] ?? [],
+                );
             }
         }
     }
@@ -317,6 +330,14 @@ class AnalyzedCache
     }
 
     /**
+     * @param  (callable(string): ?string)|null  $resolver
+     */
+    public static function resolveSurfaceUsing(?callable $resolver): void
+    {
+        static::$surfaceResolver = $resolver;
+    }
+
+    /**
      * The hash of what dependents can see of a path, without unserializing its
      * entry. An analyzed entry answers from memory; anything else is read from
      * the small file written alongside the entry.
@@ -327,10 +348,10 @@ class AnalyzedCache
             return static::$surfaces[$path];
         }
 
-        // Reading the small file beats hashing an entry that was loaded from
-        // disk, which is why it is written in the first place.
-        if (static::$persistToDisk && file_exists($surfaceFile = static::getSurfaceFilePath($path))) {
-            return static::$surfaces[$path] = file_get_contents($surfaceFile);
+        // Reading the record beats hashing an entry that was loaded from disk,
+        // which is why it is written in the first place.
+        if ($record = static::readRecord($path)) {
+            return static::$surfaces[$path] = $record['surface'];
         }
 
         if (isset(static::$cached[$path])) {
@@ -338,6 +359,48 @@ class AnalyzedCache
         }
 
         return null;
+    }
+
+    /**
+     * Whether the stored entry for a path still describes the source.
+     *
+     * True when the file has not changed and nothing it reached has changed in
+     * a way its dependents could see. Worked out from the records alone, so an
+     * unchanged file costs a few small reads rather than unserializing a graph.
+     */
+    public static function isCurrent(string $path): bool
+    {
+        if (array_key_exists($path, static::$current)) {
+            return static::$current[$path];
+        }
+
+        // Recorded graphs contain cycles. While a path is being decided it
+        // counts as holding: every member is also checked on its own terms, so
+        // a member that has really moved is caught there.
+        static::$current[$path] = true;
+
+        return static::$current[$path] = static::decide($path);
+    }
+
+    protected static function decide(string $path): bool
+    {
+        $record = static::readRecord($path);
+
+        if ($record === null) {
+            return false;
+        }
+
+        if (static::modifiedTime($path) !== $record['mtime']) {
+            return false;
+        }
+
+        foreach ($record['dependencies'] as $dependency) {
+            if (! static::dependencyStillHolds($dependency)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public static function get(string $path): ?Scope
@@ -414,24 +477,18 @@ class AnalyzedCache
             return null;
         }
 
-        $dependencies = [];
+        if (! static::isCurrent($path)) {
+            static::invalidate($path);
 
-        foreach ($data['dependencies'] as $dependency) {
-            $currentMtime = static::modifiedTime($dependency['path']);
-
-            if ($dependency['mtime'] !== $currentMtime) {
-                static::invalidate($dependency['path']);
-                static::invalidate($path);
-
-                return null;
-            }
-
-            $dependencies[$dependency['path']] = true;
+            return null;
         }
 
-        // Whoever asked for this path inherits its dependencies, so a change
-        // further down the graph still invalidates the files above it.
-        static::$dependencies[$path] = $dependencies;
+        $record = static::readRecord($path);
+
+        static::$dependencies[$path] = array_fill_keys(
+            array_column($record['dependencies'] ?? [], 'path'),
+            true,
+        );
 
         $serialized = $data['scope'];
         unset($data);
@@ -442,26 +499,66 @@ class AnalyzedCache
         return static::$cached[$path];
     }
 
+    /**
+     * Whether a recorded dependency still shows the surface it showed when the
+     * entry was written.
+     *
+     * An untouched file whose own dependencies are untouched cannot have moved,
+     * so it needs nothing further. Anything else has to be analyzed to find out
+     * whether the change reached its surface. If it did not, every entry that
+     * named it still holds, which is the whole point.
+     *
+     * @param  array{path: string, mtime: int|null, surface: string|null}  $dependency
+     */
+    protected static function dependencyStillHolds(array $dependency): bool
+    {
+        $currentMtime = static::modifiedTime($dependency['path']);
+
+        if ($currentMtime === null) {
+            return false;
+        }
+
+        if ($currentMtime === $dependency['mtime']) {
+            // A file with no record of its own has nothing underneath it to
+            // check, so its own bytes are the whole answer.
+            if (static::readRecord($dependency['path']) === null) {
+                return true;
+            }
+
+            if (static::isCurrent($dependency['path'])) {
+                return true;
+            }
+        }
+
+        if ($dependency['surface'] === null) {
+            return false;
+        }
+
+        return static::freshSurface($dependency['path']) === $dependency['surface'];
+    }
+
+    /**
+     * The surface of a path as it is now, analyzing it if that is what it takes.
+     */
+    protected static function freshSurface(string $path): ?string
+    {
+        if (isset(static::$cached[$path])) {
+            return static::surfaceHash($path);
+        }
+
+        if (static::$surfaceResolver === null) {
+            return null;
+        }
+
+        return (static::$surfaceResolver)($path);
+    }
+
     protected static function getCacheFilePayload(string $cacheFile, string $path): ?string
     {
-        $content = file_get_contents($cacheFile);
+        $serialized = static::verify(file_get_contents($cacheFile));
 
-        if (! static::$key) {
-            return $content;
-        }
-
-        if (! str_contains($content, ':')) {
+        if ($serialized === null) {
             static::invalidate($path);
-
-            return null;
-        }
-
-        [$signature, $serialized] = explode(':', $content, 2);
-
-        if (! hash_equals($signature, hash_hmac('sha256', $serialized, static::$key))) {
-            static::invalidate($path);
-
-            return null;
         }
 
         return $serialized;
@@ -469,10 +566,17 @@ class AnalyzedCache
 
     public static function invalidate(string $path): void
     {
-        unset(static::$cached[$path], static::$fileTimes[$path], static::$surfaces[$path]);
+        unset(
+            static::$cached[$path],
+            static::$fileTimes[$path],
+            static::$surfaces[$path],
+            static::$records[$path],
+        );
+
+        static::$current[$path] = false;
 
         if (static::$persistToDisk) {
-            foreach ([static::getCacheFilePath($path), static::getSurfaceFilePath($path)] as $file) {
+            foreach ([static::getCacheFilePath($path), static::getRecordFilePath($path)] as $file) {
                 if (file_exists($file)) {
                     unlink($file);
                 }
@@ -494,6 +598,8 @@ class AnalyzedCache
         static::$settled = [];
         static::$modifiedTimes = [];
         static::$surfaces = [];
+        static::$records = [];
+        static::$current = [];
     }
 
     public static function clear(): void
@@ -503,7 +609,7 @@ class AnalyzedCache
         if (static::$cacheDirectory && is_dir(static::$cacheDirectory)) {
             $files = [
                 ...glob(static::$cacheDirectory.'/*.cache'),
-                ...glob(static::$cacheDirectory.'/*.surface'),
+                ...glob(static::$cacheDirectory.'/*.record'),
             ];
 
             foreach ($files as $file) {
@@ -552,27 +658,124 @@ class AnalyzedCache
 
         $cacheFile = static::getCacheFilePath($path);
 
-        $data = [
+        $serialized = static::sign(serialize([
             'schema' => static::SCHEMA,
             'mtime' => $mtime,
-            'dependencies' => array_values(array_filter(array_map(fn ($dep) => [
-                'path' => $dep,
-                'mtime' => static::modifiedTime($dep),
-            ], array_keys($dependencies)), fn ($dep) => $dep['mtime'] !== null)),
             'scope' => $analyzed,
-        ];
-
-        $serialized = serialize($data);
-
-        if (static::$key) {
-            $serialized = hash_hmac('sha256', $serialized, static::$key).':'.$serialized;
-        }
+        ]));
 
         file_put_contents($cacheFile, $serialized);
 
-        static::$surfaces[$path] = $surface = Surface::hash($analyzed);
+        static::$surfaces[$path] = Surface::hash($analyzed);
 
-        file_put_contents(static::getSurfaceFilePath($path), $surface);
+        static::writeRecord($path, $mtime, $dependencies);
+    }
+
+    /**
+     * Store what the entry has to be judged against: the file's own time and
+     * surface, and every file it reached with the surface that file showed.
+     *
+     * A file reached while its own analysis was still open has no surface yet.
+     * It is recorded without one, which makes anything naming it invalid as
+     * soon as it changes. Those entries are analyzed again once the cycle
+     * closes, and the record written then has the real surfaces.
+     *
+     * @param  array<string, true>  $dependencies
+     */
+    protected static function writeRecord(string $path, int $mtime, array $dependencies): void
+    {
+        $recorded = [];
+
+        foreach (array_keys($dependencies) as $dependency) {
+            $dependencyMtime = static::modifiedTime($dependency);
+
+            if ($dependencyMtime === null) {
+                continue;
+            }
+
+            $recorded[] = [
+                'path' => $dependency,
+                'mtime' => $dependencyMtime,
+                'surface' => static::surfaceHash($dependency),
+            ];
+        }
+
+        static::$records[$path] = [
+            'mtime' => $mtime,
+            'surface' => static::$surfaces[$path],
+            'dependencies' => $recorded,
+        ];
+
+        static::$current[$path] = true;
+
+        file_put_contents(
+            static::getRecordFilePath($path),
+            static::sign(serialize(static::$records[$path])),
+        );
+    }
+
+    /**
+     * @return array{mtime: int, surface: string, dependencies: list<array{path: string, mtime: int, surface: string|null}>}|null
+     */
+    protected static function readRecord(string $path): ?array
+    {
+        if (array_key_exists($path, static::$records)) {
+            return static::$records[$path] ?: null;
+        }
+
+        if (! static::$persistToDisk) {
+            return null;
+        }
+
+        $recordFile = static::getRecordFilePath($path);
+
+        if (! file_exists($recordFile)) {
+            static::$records[$path] = false;
+
+            return null;
+        }
+
+        $serialized = static::verify(file_get_contents($recordFile));
+
+        try {
+            $record = $serialized === null ? null : unserialize($serialized);
+        } catch (Throwable) {
+            $record = null;
+        }
+
+        if (! is_array($record) || ! isset($record['mtime'], $record['surface'], $record['dependencies'])) {
+            static::$records[$path] = false;
+
+            return null;
+        }
+
+        return static::$records[$path] = $record;
+    }
+
+    protected static function sign(string $serialized): string
+    {
+        if (! static::$key) {
+            return $serialized;
+        }
+
+        return hash_hmac('sha256', $serialized, static::$key).':'.$serialized;
+    }
+
+    protected static function verify(string $content): ?string
+    {
+        if (! static::$key) {
+            return $content;
+        }
+
+        if (! str_contains($content, ':')) {
+            return null;
+        }
+
+        [$signature, $serialized] = explode(':', $content, 2);
+
+        return hash_equals($signature, hash_hmac('sha256', $serialized, static::$key))
+            ? $serialized
+            : null;
     }
 
     protected static function getCacheFilePath(string $path): string
@@ -580,8 +783,8 @@ class AnalyzedCache
         return static::$cacheDirectory.'/'.md5($path).'.cache';
     }
 
-    protected static function getSurfaceFilePath(string $path): string
+    protected static function getRecordFilePath(string $path): string
     {
-        return static::$cacheDirectory.'/'.md5($path).'.surface';
+        return static::$cacheDirectory.'/'.md5($path).'.record';
     }
 }

--- a/src/Analyzer/AnalyzedCache.php
+++ b/src/Analyzer/AnalyzedCache.php
@@ -39,24 +39,34 @@ class AnalyzedCache
     protected static array $framePaths = [];
 
     /**
-     * Whether each frame skipped a file that was still being analyzed, which
-     * leaves its dependency list incomplete.
+     * Whether each frame took part in a cycle, whether by giving up on a file
+     * itself or by asking one that did.
      *
      * @var list<bool>
      */
     protected static array $frameTainted = [];
 
+    /**
+     * Whether each frame gave up on a file itself. Those are the files that
+     * resolved something against nothing, so they are where a second look
+     * starts.
+     *
+     * @var list<bool>
+     */
+    protected static array $frameBailed = [];
+
     /** Index of the outermost frame taking part in an unresolved cycle. */
     protected static ?int $cycleFloor = null;
 
-    /** @var list<array{path: string, scope: Scope, mtime: int}> */
+    /** @var list<array{path: string, scope: Scope, mtime: int, bailed: bool}> */
     protected static array $deferred = [];
 
     /**
      * Members of cycles that have just closed. Each was analyzed while another
-     * member was still open, so it resolved part of its work against nothing.
+     * member was still open, so part of its work was resolved against nothing,
+     * either its own or that of a file it asked.
      *
-     * @var list<string>
+     * @var list<array{path: string, bailed: bool}>
      */
     protected static array $settled = [];
 
@@ -136,6 +146,7 @@ class AnalyzedCache
         static::$frames[] = [];
         static::$framePaths[] = $path;
         static::$frameTainted[] = false;
+        static::$frameBailed[] = false;
     }
 
     /**
@@ -151,6 +162,7 @@ class AnalyzedCache
         }
 
         static::$frameTainted[array_key_last(static::$frameTainted)] = true;
+        static::$frameBailed[array_key_last(static::$frameBailed)] = true;
 
         // The file should always be somewhere on the stack, since that is what
         // makes it in progress. Fall back to the outermost frame rather than
@@ -179,6 +191,7 @@ class AnalyzedCache
 
         $dependencies = array_pop(static::$frames);
         $tainted = array_pop(static::$frameTainted);
+        array_pop(static::$frameBailed);
         array_pop(static::$framePaths);
 
         unset($dependencies[$path]);
@@ -211,7 +224,7 @@ class AnalyzedCache
         static::$deferred = [];
 
         foreach ($deferred as $entry) {
-            static::$settled[] = $entry['path'];
+            static::$settled[] = ['path' => $entry['path'], 'bailed' => $entry['bailed']];
 
             if (static::$persistToDisk) {
                 static::persistToDisk(
@@ -226,9 +239,9 @@ class AnalyzedCache
 
     /**
      * Hand back the members of any cycle that has closed since this was last
-     * called, and forget them.
+     * called, and forget them. Each says whether it gave up on a file itself.
      *
-     * @return list<string>
+     * @return list<array{path: string, bailed: bool}>
      */
     public static function takeSettled(): array
     {
@@ -319,7 +332,12 @@ class AnalyzedCache
 
         // Its dependency list is still missing whatever the cycle resolves to.
         if (static::$cycleFloor !== null && (static::$frameTainted[array_key_last(static::$frameTainted)] ?? false)) {
-            static::$deferred[] = ['path' => $path, 'scope' => $analyzed, 'mtime' => $mtime];
+            static::$deferred[] = [
+                'path' => $path,
+                'scope' => $analyzed,
+                'mtime' => $mtime,
+                'bailed' => static::$frameBailed[array_key_last(static::$frameBailed)] ?? false,
+            ];
 
             return;
         }
@@ -327,6 +345,16 @@ class AnalyzedCache
         if (static::$persistToDisk) {
             static::persistToDisk($path, $analyzed, $mtime, static::pendingDependencies($path));
         }
+    }
+
+    /**
+     * The files a path reached, as recorded when it was analyzed.
+     *
+     * @return list<string>
+     */
+    public static function dependenciesOf(string $path): array
+    {
+        return array_keys(static::$dependencies[$path] ?? []);
     }
 
     /**
@@ -593,6 +621,7 @@ class AnalyzedCache
         static::$frames = [];
         static::$framePaths = [];
         static::$frameTainted = [];
+        static::$frameBailed = [];
         static::$cycleFloor = null;
         static::$deferred = [];
         static::$settled = [];

--- a/src/Analyzer/Analyzer.php
+++ b/src/Analyzer/Analyzer.php
@@ -18,7 +18,13 @@ class Analyzer
     public function __construct(
         protected Parser $parser,
     ) {
-        //
+        // Deciding whether a cached entry still holds means knowing what its
+        // dependencies look like now, and only an analysis can say.
+        AnalyzedCache::resolveSurfaceUsing(function (string $path): ?string {
+            $analyzed = $this->analyze($path)->analyzed();
+
+            return $analyzed === null ? null : Surface::hash($analyzed);
+        });
     }
 
     public function analyzeClass(string $className)

--- a/src/Analyzer/Analyzer.php
+++ b/src/Analyzer/Analyzer.php
@@ -107,9 +107,13 @@ class Analyzer
      * Each of them ran while another member was still open, so wherever they
      * reached for it they resolved against an empty scope. Which member that
      * was depends on where the analysis happened to start, so leaving those
-     * answers in place makes the cache depend on visit order. One member is
-     * re-analyzed at a time, with the rest left in the cache, so each of them
-     * sees a finished answer for everything it reaches.
+     * answers in place makes the cache depend on visit order.
+     *
+     * Only the members that gave up on a file themselves are looked at to begin
+     * with. A member that merely asked one of those is looked at when, and only
+     * when, the answer it was given moved, which is what the surface hashes are
+     * for. One member is analyzed at a time with the rest left in the cache, so
+     * each sees a finished answer for everything it reaches.
      */
     protected function settle(): void
     {
@@ -127,13 +131,7 @@ class Analyzer
         $this->settling = true;
 
         try {
-            foreach ($members as $member) {
-                AnalyzedCache::invalidate($member);
-
-                Debug::log(static fn () => '♻️ Re-analyzing settled cycle member: '.self::shortPath($member));
-
-                $this->analyze($member);
-            }
+            $this->settleMembers($members);
         } finally {
             $this->settling = false;
 
@@ -145,6 +143,60 @@ class Analyzer
                 $this->analyzed = $mine;
             }
         }
+    }
+
+    /**
+     * @param  list<array{path: string, bailed: bool}>  $members
+     */
+    protected function settleMembers(array $members): void
+    {
+        $waiting = [];
+
+        foreach ($members as $member) {
+            $waiting[$member['path']] = $member['bailed'];
+        }
+
+        $queue = array_keys(array_filter($waiting));
+
+        while ($queue !== []) {
+            $moved = [];
+
+            foreach ($queue as $path) {
+                unset($waiting[$path]);
+
+                if ($this->reanalyze($path)) {
+                    $moved[$path] = true;
+                }
+            }
+
+            $queue = [];
+
+            foreach ($waiting as $path => $bailed) {
+                foreach (AnalyzedCache::dependenciesOf($path) as $dependency) {
+                    if (isset($moved[$dependency])) {
+                        $queue[] = $path;
+
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Analyze a path again, and say whether what dependents can see of it moved.
+     */
+    protected function reanalyze(string $path): bool
+    {
+        $before = AnalyzedCache::surfaceHash($path);
+
+        AnalyzedCache::invalidate($path);
+
+        Debug::log(static fn () => '♻️ Re-analyzing settled cycle member: '.self::shortPath($path));
+
+        $this->analyze($path);
+
+        return AnalyzedCache::surfaceHash($path) !== $before;
     }
 
     protected static function shortPath(string $path): string

--- a/src/Analyzer/Surface.php
+++ b/src/Analyzer/Surface.php
@@ -121,7 +121,9 @@ class Surface
             'arrayable '.var_export($result->isArrayable(), true),
         ];
 
-        foreach ($result->publicMethods() as $name => $method) {
+        $lines[] = 'class ignore'.static::ignoreState($result);
+
+        foreach ($result->methods() as $name => $method) {
             $lines = [...$lines, ...static::methodLines('method '.$name, $method)];
         }
 
@@ -131,7 +133,8 @@ class Surface
                 .' attribute='.var_export($property->modelAttribute, true)
                 .' relation='.var_export($property->modelRelation, true)
                 .' readonly='.var_export($property->readOnly, true)
-                .' writeonly='.var_export($property->writeOnly, true);
+                .' writeonly='.var_export($property->writeOnly, true)
+                .static::ignoreState($property);
         }
 
         foreach ($result->constants() as $name => $constant) {
@@ -160,7 +163,8 @@ class Surface
 
         $lines = [
             $prefix.' ('.implode(', ', $parameters).') -> '.implode(' + ', $returns)
-                .' relation='.var_export($method->isModelRelation(), true),
+                .' relation='.var_export($method->isModelRelation(), true)
+                .static::ignoreState($method),
         ];
 
         foreach ($method->validationRules() as $key => $rules) {
@@ -168,6 +172,28 @@ class Surface
         }
 
         return $lines;
+    }
+
+    /**
+     * An ignore marker takes a declaration out of everything a dependent can
+     * read, so putting one on, taking one off, or changing what it is
+     * conditional on all move the surface.
+     *
+     * Whether a condition holds is answered when the marker is read, not when
+     * the file was analyzed, so the answer is recorded alongside the condition
+     * itself. A run that answers differently sees a different surface.
+     */
+    protected static function ignoreState(object $subject): string
+    {
+        $marker = $subject->ignoreMarker();
+
+        if ($marker === null) {
+            return ' ignored=false';
+        }
+
+        return ' ignored='.var_export($marker->hides(), true)
+            .' unless='.json_encode($marker->unless)
+            .' when='.json_encode($marker->when);
     }
 
     protected static function fileHash(?string $path): string

--- a/src/Analyzer/Surface.php
+++ b/src/Analyzer/Surface.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Laravel\Surveyor\Analyzer;
+
+use Laravel\Surveyor\Analysis\Scope;
+use Laravel\Surveyor\Analyzed\ClassLikeResult;
+use Laravel\Surveyor\Analyzed\MethodResult;
+use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
+use Throwable;
+
+/**
+ * Everything a dependent can read off an analyzed file, as text.
+ *
+ * A file's own analysis changes whenever its body does. What its dependents
+ * can see is narrower: the classes it declares, their methods, what those
+ * methods take and return, and the imports names are resolved against. Two
+ * analyses that agree here cannot lead a dependent to a different answer, so
+ * this is what a cache entry can be fingerprinted on.
+ *
+ * The state tracker is left out. It holds the variables of the run that
+ * produced the entry, nothing reads it back, and it does not survive
+ * re-analysis unchanged.
+ */
+class Surface
+{
+    public static function hash(Scope $scope): string
+    {
+        return hash('xxh128', implode("\n", static::lines($scope)));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function lines(Scope $scope): array
+    {
+        $lines = static::scopeLines($scope);
+        $result = $scope->result();
+
+        if ($result instanceof MethodResult) {
+            $lines = [...$lines, ...static::methodLines('method '.$result->name(), $result)];
+        } elseif ($result instanceof ClassLikeResult) {
+            $lines = [...$lines, ...static::classLines($result)];
+        } else {
+            // Some files record nothing observable. An enum is the common case:
+            // its cases are never analyzed, dependents read them off PHP's own
+            // reflection, and two enums in one namespace look identical here.
+            // With no surface to compare, the bytes stand in for one, so any
+            // edit to such a file counts as a change to its surface.
+            $lines[] = 'no result, bytes '.static::fileHash($scope->fullPath());
+        }
+
+        // Methods and properties are keyed by name, so sorting keeps the hash
+        // independent of the order they were recorded in.
+        sort($lines);
+
+        return $lines;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected static function scopeLines(Scope $scope): array
+    {
+        $lines = [
+            'scope entity '.($scope->entityName() ?? '-'),
+            'scope method '.($scope->methodName() ?? '-'),
+            'scope namespace '.($scope->namespace() ?? '-'),
+            'scope extends '.implode(',', $scope->extends()),
+            'scope implements '.implode(',', $scope->implements()),
+            'scope traits '.implode(',', $scope->traits()),
+        ];
+
+        foreach ($scope->uses() as $alias => $use) {
+            $lines[] = 'scope use '.$alias.' = '.$use;
+        }
+
+        foreach ($scope->constants() as $name => $type) {
+            $lines[] = 'scope constant '.$name.' '.static::describe($type);
+        }
+
+        foreach ($scope->parameters() as $name => $type) {
+            $lines[] = 'scope parameter '.$name.' '.static::describe($type);
+        }
+
+        foreach ($scope->returnTypes() as $index => $type) {
+            $lines[] = 'scope return '.$index.' '.static::describe($type);
+        }
+
+        foreach ($scope->macros() as $class => $macros) {
+            foreach ($macros as $name => $type) {
+                $lines[] = 'scope macro '.$class.'::'.$name.' '.static::describe($type);
+            }
+        }
+
+        foreach ($scope->validationRules() as $key => $rules) {
+            $lines[] = 'scope rule '.$key.' = '.json_encode($rules);
+        }
+
+        foreach ($scope->getTemplateTags() as $index => $tag) {
+            $lines[] = 'scope template '.$index.' '.static::describe($tag);
+        }
+
+        if ($receiver = $scope->getReceiverType()) {
+            $lines[] = 'scope receiver '.static::describe($receiver);
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected static function classLines(ClassLikeResult $result): array
+    {
+        $lines = [
+            'class '.$result->name(),
+            'namespace '.($result->namespace() ?? '-'),
+            'entity '.$result->entityType()->value,
+            'extends '.implode(',', $result->extends()),
+            'implements '.implode(',', $result->implements()),
+            'arrayable '.var_export($result->isArrayable(), true),
+        ];
+
+        foreach ($result->publicMethods() as $name => $method) {
+            $lines = [...$lines, ...static::methodLines('method '.$name, $method)];
+        }
+
+        foreach ($result->properties() as $name => $property) {
+            $lines[] = 'property '.$name.' '.$property->visibility.' '.static::describe($property->type)
+                .' doc='.var_export($property->fromDocBlock, true)
+                .' attribute='.var_export($property->modelAttribute, true)
+                .' relation='.var_export($property->modelRelation, true)
+                .' readonly='.var_export($property->readOnly, true)
+                .' writeonly='.var_export($property->writeOnly, true);
+        }
+
+        foreach ($result->constants() as $name => $constant) {
+            $lines[] = 'constant '.$name.' '.static::describe($constant->type);
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected static function methodLines(string $prefix, MethodResult $method): array
+    {
+        $parameters = [];
+
+        foreach ($method->parameters() as $name => $type) {
+            $parameters[] = $name.' '.static::describe($type);
+        }
+
+        $returns = [];
+
+        foreach ($method->returnTypes() as $entry) {
+            $returns[] = static::describe($entry['type']);
+        }
+
+        $lines = [
+            $prefix.' ('.implode(', ', $parameters).') -> '.implode(' + ', $returns)
+                .' relation='.var_export($method->isModelRelation(), true),
+        ];
+
+        foreach ($method->validationRules() as $key => $rules) {
+            $lines[] = $prefix.' rule '.$key.' = '.json_encode($rules);
+        }
+
+        return $lines;
+    }
+
+    protected static function fileHash(?string $path): string
+    {
+        if ($path === null || ! is_file($path)) {
+            return '-';
+        }
+
+        return hash_file('xxh128', $path);
+    }
+
+    protected static function describe(mixed $type): string
+    {
+        if (! $type instanceof TypeContract) {
+            return $type === null ? '-' : get_debug_type($type);
+        }
+
+        try {
+            $id = $type->id();
+        } catch (Throwable) {
+            // A type that cannot name itself still has to hash to the same
+            // thing every time, so the class name stands in for its id.
+            $id = 'unnameable';
+        }
+
+        return $type::class.'('.$id.')'
+            .($type->isNullable() ? '|null' : '')
+            .($type->isOptional() ? '|optional' : '');
+    }
+}

--- a/tests/Unit/Analyzer/AnalyzedCacheTest.php
+++ b/tests/Unit/Analyzer/AnalyzedCacheTest.php
@@ -3,6 +3,7 @@
 use Laravel\Surveyor\Analysis\Scope;
 use Laravel\Surveyor\Analyzer\AnalyzedCache;
 use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Analyzer\Surface;
 
 uses()->group('cache');
 
@@ -68,7 +69,7 @@ function createCacheDir(): string
 function cleanupCacheDir(string $dir): void
 {
     if (is_dir($dir)) {
-        foreach (glob($dir.'/*.cache') as $file) {
+        foreach ([...glob($dir.'/*.cache'), ...glob($dir.'/*.surface')] as $file) {
             unlink($file);
         }
 
@@ -813,5 +814,76 @@ describe('integration with Analyzer', function () {
         expect($scope1)->not->toBe($scope2);
 
         unlink($fixture);
+    });
+});
+
+describe('surface hashes', function () {
+    it('writes a surface alongside a persisted entry', function () {
+        $dir = createCacheDir();
+        AnalyzedCache::enableDiskCache($dir);
+
+        $fixture = createTestClassFixture('SurfaceSubject', 'public function test(): string { return "x"; }');
+        $analyzed = app(Analyzer::class)->analyze($fixture);
+
+        expect(glob($dir.'/*.surface'))->toHaveCount(1);
+        expect(AnalyzedCache::surfaceHash($fixture))->toBe(Surface::hash($analyzed->analyzed()));
+
+        unlink($fixture);
+        cleanupCacheDir($dir);
+    });
+
+    it('reads a surface back without loading the entry', function () {
+        $dir = createCacheDir();
+        AnalyzedCache::enableDiskCache($dir);
+
+        $fixture = createTestClassFixture('SurfaceSubject', 'public function test(): string { return "x"; }');
+        app(Analyzer::class)->analyze($fixture);
+
+        $expected = AnalyzedCache::surfaceHash($fixture);
+
+        AnalyzedCache::clearMemory();
+
+        expect(AnalyzedCache::surfaceHash($fixture))->toBe($expected);
+
+        // Reading the surface must not pull the entry into memory.
+        $cached = (new ReflectionProperty(AnalyzedCache::class, 'cached'))->getValue();
+        expect($cached)->toBe([]);
+
+        unlink($fixture);
+        cleanupCacheDir($dir);
+    });
+
+    it('answers from memory when nothing is persisted', function () {
+        $fixture = createTestClassFixture('SurfaceSubject', 'public function test(): string { return "x"; }');
+        $analyzed = app(Analyzer::class)->analyze($fixture);
+
+        expect(AnalyzedCache::surfaceHash($fixture))->toBe(Surface::hash($analyzed->analyzed()));
+
+        unlink($fixture);
+    });
+
+    it('forgets the surface when the entry is invalidated', function () {
+        $dir = createCacheDir();
+        AnalyzedCache::enableDiskCache($dir);
+
+        $fixture = createTestClassFixture('SurfaceSubject', 'public function test(): string { return "x"; }');
+        app(Analyzer::class)->analyze($fixture);
+
+        AnalyzedCache::invalidate($fixture);
+
+        expect(glob($dir.'/*.surface'))->toBeEmpty();
+        expect(AnalyzedCache::surfaceHash($fixture))->toBeNull();
+
+        unlink($fixture);
+        cleanupCacheDir($dir);
+    });
+
+    it('has no surface for a path it never analyzed', function () {
+        $dir = createCacheDir();
+        AnalyzedCache::enableDiskCache($dir);
+
+        expect(AnalyzedCache::surfaceHash('/nowhere/Missing.php'))->toBeNull();
+
+        cleanupCacheDir($dir);
     });
 });

--- a/tests/Unit/Analyzer/AnalyzedCacheTest.php
+++ b/tests/Unit/Analyzer/AnalyzedCacheTest.php
@@ -30,8 +30,13 @@ function resetCacheDirectory(): void
     $persistProp = $reflection->getProperty('persistToDisk');
     $persistProp->setValue(null, false);
 
-    $depsProp = $reflection->getProperty('dependencies');
-    $depsProp->setValue(null, []);
+    foreach (['dependencies', 'records', 'current', 'surfaces'] as $property) {
+        $reflection->getProperty($property)->setValue(null, []);
+    }
+
+    // Registered by the analyzer's constructor, so it outlives the test that
+    // built one and would decide validity for every test after it.
+    AnalyzedCache::resolveSurfaceUsing(null);
 
     // A test that fails mid-analysis leaves a frame open, which would then
     // attach its dependencies to whatever runs next.
@@ -69,7 +74,7 @@ function createCacheDir(): string
 function cleanupCacheDir(string $dir): void
 {
     if (is_dir($dir)) {
-        foreach ([...glob($dir.'/*.cache'), ...glob($dir.'/*.surface')] as $file) {
+        foreach ([...glob($dir.'/*.cache'), ...glob($dir.'/*.record')] as $file) {
             unlink($file);
         }
 
@@ -550,7 +555,7 @@ describe('dependency tracking', function () {
         expect(dependenciesFor('/path/to/second.php'))->toBe(['/path/to/dep2.php']);
     });
 
-    it('gives a file the dependencies of the files it depends on', function () {
+    it('records only the files a file reached itself', function () {
         AnalyzedCache::beginAnalysis('/path/to/a.php');
         AnalyzedCache::addDependency('/path/to/b.php');
 
@@ -560,10 +565,7 @@ describe('dependency tracking', function () {
 
         AnalyzedCache::endAnalysis('/path/to/a.php');
 
-        expect(dependenciesFor('/path/to/a.php'))
-            ->toContain('/path/to/b.php')
-            ->toContain('/path/to/c.php');
-
+        expect(dependenciesFor('/path/to/a.php'))->toBe(['/path/to/b.php']);
         expect(dependenciesFor('/path/to/b.php'))->toBe(['/path/to/c.php']);
     });
 
@@ -594,12 +596,13 @@ describe('dependency tracking', function () {
         $cacheFiles = glob($dir.'/*.cache');
         expect($cacheFiles)->toHaveCount(1);
 
-        $content = file_get_contents($cacheFiles[0]);
-        $cacheData = unserialize(getCacheFilePayload($content));
-        expect($cacheData)->toHaveKey('dependencies');
-        expect(count($cacheData['dependencies']))->toBeGreaterThanOrEqual(1);
+        $recordFiles = glob($dir.'/*.record');
+        expect($recordFiles)->toHaveCount(1);
 
-        $depPaths = array_column($cacheData['dependencies'], 'path');
+        $record = unserialize(getCacheFilePayload(file_get_contents($recordFiles[0])));
+        expect($record)->toHaveKey('dependencies');
+
+        $depPaths = array_column($record['dependencies'], 'path');
         expect($depPaths)->toContain($depFixture);
 
         unlink($mainFixture);
@@ -818,14 +821,14 @@ describe('integration with Analyzer', function () {
 });
 
 describe('surface hashes', function () {
-    it('writes a surface alongside a persisted entry', function () {
+    it('writes a record alongside a persisted entry', function () {
         $dir = createCacheDir();
         AnalyzedCache::enableDiskCache($dir);
 
         $fixture = createTestClassFixture('SurfaceSubject', 'public function test(): string { return "x"; }');
         $analyzed = app(Analyzer::class)->analyze($fixture);
 
-        expect(glob($dir.'/*.surface'))->toHaveCount(1);
+        expect(glob($dir.'/*.record'))->toHaveCount(1);
         expect(AnalyzedCache::surfaceHash($fixture))->toBe(Surface::hash($analyzed->analyzed()));
 
         unlink($fixture);
@@ -871,7 +874,7 @@ describe('surface hashes', function () {
 
         AnalyzedCache::invalidate($fixture);
 
-        expect(glob($dir.'/*.surface'))->toBeEmpty();
+        expect(glob($dir.'/*.record'))->toBeEmpty();
         expect(AnalyzedCache::surfaceHash($fixture))->toBeNull();
 
         unlink($fixture);
@@ -884,6 +887,144 @@ describe('surface hashes', function () {
 
         expect(AnalyzedCache::surfaceHash('/nowhere/Missing.php'))->toBeNull();
 
+        cleanupCacheDir($dir);
+    });
+});
+
+describe('validity by surface', function () {
+    /**
+     * Two files, one reaching the other, both persisted.
+     *
+     * @return array{0: string, 1: string}
+     */
+    function dependentPair(): array
+    {
+        $dependent = createTestClassFixture('Dependent', 'public function value() {}');
+        $dependency = createTestClassFixture('Dependency', 'public function number() {}');
+
+        AnalyzedCache::beginAnalysis($dependency);
+        AnalyzedCache::add($dependency, tap(new Scope, fn ($scope) => $scope->setPath($dependency)));
+        AnalyzedCache::endAnalysis($dependency);
+
+        AnalyzedCache::beginAnalysis($dependent);
+        AnalyzedCache::addDependency($dependency);
+        AnalyzedCache::add($dependent, tap(new Scope, fn ($scope) => $scope->setPath($dependent)));
+        AnalyzedCache::endAnalysis($dependent);
+
+        return [$dependent, $dependency];
+    }
+
+    it('keeps a dependent when the dependency changed but its surface did not', function () {
+        $dir = createCacheDir();
+        AnalyzedCache::enableDiskCache($dir);
+
+        [$dependent, $dependency] = dependentPair();
+        $unmoved = AnalyzedCache::surfaceHash($dependency);
+
+        sleep(1);
+        file_put_contents($dependency, "<?php\nclass Dependency { public function number() { return 2; } }");
+
+        AnalyzedCache::clearMemory();
+
+        // Analyzing the changed file lands on the same surface it had before.
+        AnalyzedCache::resolveSurfaceUsing(fn () => $unmoved);
+
+        expect(AnalyzedCache::get($dependent))->not->toBeNull();
+
+        unlink($dependent);
+        unlink($dependency);
+        cleanupCacheDir($dir);
+    });
+
+    it('drops a dependent when the dependency surface moves', function () {
+        $dir = createCacheDir();
+        AnalyzedCache::enableDiskCache($dir);
+
+        [$dependent, $dependency] = dependentPair();
+
+        sleep(1);
+        file_put_contents($dependency, "<?php\nclass Dependency { public function other(): string { return 'x'; } }");
+
+        AnalyzedCache::clearMemory();
+
+        AnalyzedCache::resolveSurfaceUsing(fn () => 'a-different-surface');
+
+        expect(AnalyzedCache::get($dependent))->toBeNull();
+
+        unlink($dependent);
+        unlink($dependency);
+        cleanupCacheDir($dir);
+    });
+
+    it('drops a dependent two levels up when a surface moves', function () {
+        $dir = createCacheDir();
+        AnalyzedCache::enableDiskCache($dir);
+
+        $a = createTestClassFixture('AClass', 'public function a() {}');
+        $b = createTestClassFixture('BClass', 'public function b() {}');
+        $c = createTestClassFixture('CClass', 'public function c() {}');
+
+        // A reaches B, B reaches C. Nothing links A to C.
+        AnalyzedCache::beginAnalysis($a);
+        AnalyzedCache::addDependency($b);
+
+        AnalyzedCache::beginAnalysis($b);
+        AnalyzedCache::addDependency($c);
+        AnalyzedCache::add($b, tap(new Scope, fn ($scope) => $scope->setPath($b)));
+        AnalyzedCache::endAnalysis($b);
+
+        AnalyzedCache::add($a, tap(new Scope, fn ($scope) => $scope->setPath($a)));
+        AnalyzedCache::endAnalysis($a);
+
+        sleep(1);
+        file_put_contents($c, "<?php\nclass CClass { public function moved(): string { return 'x'; } }");
+
+        AnalyzedCache::clearMemory();
+
+        AnalyzedCache::resolveSurfaceUsing(fn () => 'a-different-surface');
+
+        expect(AnalyzedCache::get($a))->toBeNull();
+
+        unlink($a);
+        unlink($b);
+        unlink($c);
+        cleanupCacheDir($dir);
+    });
+
+    it('keeps a dependent two levels up when only a body changes', function () {
+        $dir = createCacheDir();
+        AnalyzedCache::enableDiskCache($dir);
+
+        $a = createTestClassFixture('AClass', 'public function a() {}');
+        $b = createTestClassFixture('BClass', 'public function b() {}');
+        $c = createTestClassFixture('CClass', 'public function c() {}');
+
+        AnalyzedCache::beginAnalysis($a);
+        AnalyzedCache::addDependency($b);
+
+        AnalyzedCache::beginAnalysis($b);
+        AnalyzedCache::addDependency($c);
+        AnalyzedCache::add($b, tap(new Scope, fn ($scope) => $scope->setPath($b)));
+        AnalyzedCache::endAnalysis($b);
+
+        AnalyzedCache::add($a, tap(new Scope, fn ($scope) => $scope->setPath($a)));
+        AnalyzedCache::endAnalysis($a);
+
+        $unmovedB = AnalyzedCache::surfaceHash($b);
+        $unmovedC = AnalyzedCache::surfaceHash($c);
+
+        sleep(1);
+        file_put_contents($c, "<?php\nclass CClass { public function c() { return 2; } }");
+
+        AnalyzedCache::clearMemory();
+
+        AnalyzedCache::resolveSurfaceUsing(fn (string $path) => $path === $b ? $unmovedB : $unmovedC);
+
+        expect(AnalyzedCache::get($a))->not->toBeNull();
+
+        unlink($a);
+        unlink($b);
+        unlink($c);
         cleanupCacheDir($dir);
     });
 });

--- a/tests/Unit/Analyzer/AnalyzedCacheTest.php
+++ b/tests/Unit/Analyzer/AnalyzedCacheTest.php
@@ -1028,3 +1028,50 @@ describe('validity by surface', function () {
         cleanupCacheDir($dir);
     });
 });
+
+describe('settling cycles', function () {
+    it('says which members gave up on a file themselves', function () {
+        $root = createTestClassFixture('RootClass', 'public function root() {}');
+        $middle = createTestClassFixture('MiddleClass', 'public function middle() {}');
+        $inner = createTestClassFixture('InnerClass', 'public function inner() {}');
+
+        // Root reaches middle, middle reaches inner, and inner asks for root
+        // while root is still open.
+        AnalyzedCache::beginAnalysis($root);
+        AnalyzedCache::addDependency($middle);
+
+        AnalyzedCache::beginAnalysis($middle);
+        AnalyzedCache::addDependency($inner);
+
+        AnalyzedCache::beginAnalysis($inner);
+        AnalyzedCache::addDependency($root);
+        AnalyzedCache::noteCycle($root);
+        AnalyzedCache::add($inner, tap(new Scope, fn ($scope) => $scope->setPath($inner)));
+        AnalyzedCache::endAnalysis($inner);
+
+        AnalyzedCache::add($middle, tap(new Scope, fn ($scope) => $scope->setPath($middle)));
+        AnalyzedCache::endAnalysis($middle);
+
+        AnalyzedCache::add($root, tap(new Scope, fn ($scope) => $scope->setPath($root)));
+        AnalyzedCache::endAnalysis($root);
+
+        $settled = collect(AnalyzedCache::takeSettled())->pluck('bailed', 'path');
+
+        expect($settled[$inner])->toBeTrue();
+        expect($settled[$middle])->toBeFalse();
+        expect($settled[$root])->toBeFalse();
+
+        unlink($root);
+        unlink($middle);
+        unlink($inner);
+    });
+
+    it('reports what a member reached, so settling can follow the edges', function () {
+        AnalyzedCache::beginAnalysis('/path/to/middle.php');
+        AnalyzedCache::addDependency('/path/to/inner.php');
+        AnalyzedCache::endAnalysis('/path/to/middle.php');
+
+        expect(AnalyzedCache::dependenciesOf('/path/to/middle.php'))->toBe(['/path/to/inner.php']);
+        expect(AnalyzedCache::dependenciesOf('/path/to/unknown.php'))->toBe([]);
+    });
+});

--- a/tests/Unit/Analyzer/SurfaceTest.php
+++ b/tests/Unit/Analyzer/SurfaceTest.php
@@ -1,0 +1,176 @@
+<?php
+
+use Laravel\Surveyor\Analyzer\AnalyzedCache;
+use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Analyzer\Surface;
+
+uses()->group('integration');
+
+beforeEach(function () {
+    AnalyzedCache::clear();
+
+    app()->forgetInstance(Analyzer::class);
+});
+
+afterEach(function () {
+    AnalyzedCache::clear();
+});
+
+/**
+ * Analyze a file from an empty cache and hash what a dependent could see.
+ */
+function surfaceHashOf(string $path): string
+{
+    AnalyzedCache::clear();
+
+    app()->forgetInstance(Analyzer::class);
+
+    return Surface::hash(app(Analyzer::class)->analyze($path)->analyzed());
+}
+
+function rewriteFixture(string $path, string $content): void
+{
+    file_put_contents($path, "<?php\n\n".$content);
+}
+
+const SURFACE_SUBJECT = '
+namespace App\Surface;
+
+class Subject
+{
+    public const KIND = "subject";
+
+    public string $name = "subject";
+
+    public function label(string $prefix): string
+    {
+        return $prefix.$this->name;
+    }
+}';
+
+it('hashes the same source to the same surface', function () {
+    $fixture = createPhpFixture(SURFACE_SUBJECT);
+
+    expect(surfaceHashOf($fixture))->toBe(surfaceHashOf($fixture));
+
+    unlink($fixture);
+});
+
+it('leaves the surface alone when only a method body changes', function () {
+    $fixture = createPhpFixture(SURFACE_SUBJECT);
+
+    $before = surfaceHashOf($fixture);
+
+    rewriteFixture($fixture, str_replace(
+        'return $prefix.$this->name;',
+        'return $prefix.strtoupper($this->name);',
+        SURFACE_SUBJECT,
+    ));
+
+    expect(surfaceHashOf($fixture))->toBe($before);
+
+    unlink($fixture);
+});
+
+it('moves the surface when a public method is added', function () {
+    $fixture = createPhpFixture(SURFACE_SUBJECT);
+
+    $before = surfaceHashOf($fixture);
+
+    rewriteFixture($fixture, str_replace(
+        '    public function label(',
+        "    public function extra(): int\n    {\n        return 1;\n    }\n\n    public function label(",
+        SURFACE_SUBJECT,
+    ));
+
+    expect(surfaceHashOf($fixture))->not->toBe($before);
+
+    unlink($fixture);
+});
+
+it('moves the surface when a return type changes', function () {
+    $fixture = createPhpFixture(SURFACE_SUBJECT);
+
+    $before = surfaceHashOf($fixture);
+
+    rewriteFixture($fixture, str_replace(
+        'public function label(string $prefix): string',
+        'public function label(string $prefix): ?string',
+        SURFACE_SUBJECT,
+    ));
+
+    expect(surfaceHashOf($fixture))->not->toBe($before);
+
+    unlink($fixture);
+});
+
+it('moves the surface when an import changes what a name means', function () {
+    $body = '
+namespace App\\Surface;
+
+use App\\Surface\\%s\\Marker;
+
+class Importer
+{
+    public function stamp(Marker $marker): Marker
+    {
+        return $marker;
+    }
+}';
+
+    $first = createPhpFixture(sprintf($body, 'One'));
+    $second = createPhpFixture(sprintf($body, 'Two'));
+
+    expect(surfaceHashOf($first))->not->toBe(surfaceHashOf($second));
+
+    unlink($first);
+    unlink($second);
+});
+
+it('separates two files that record nothing observable', function () {
+    $first = createPhpFixture('
+namespace App\Surface;
+
+enum FirstKind: string
+{
+    case ALPHA = "alpha";
+}');
+
+    $second = createPhpFixture('
+namespace App\Surface;
+
+enum SecondKind: string
+{
+    case ALPHA = "alpha";
+}');
+
+    expect(surfaceHashOf($first))->not->toBe(surfaceHashOf($second));
+
+    unlink($first);
+    unlink($second);
+});
+
+it('moves the surface of an enum when a case changes', function () {
+    $fixture = createPhpFixture('
+namespace App\Surface;
+
+enum Kind: string
+{
+    case ALPHA = "alpha";
+}');
+
+    $before = surfaceHashOf($fixture);
+
+    rewriteFixture($fixture, '
+namespace App\Surface;
+
+enum Kind: string
+{
+    case ALPHA = "alpha";
+    case BETA = "beta";
+}');
+
+    expect(surfaceHashOf($fixture))->not->toBe($before);
+
+    unlink($fixture);
+});

--- a/tests/Unit/Analyzer/SurfaceTest.php
+++ b/tests/Unit/Analyzer/SurfaceTest.php
@@ -174,3 +174,35 @@ enum Kind: string
 
     unlink($fixture);
 });
+
+it('moves the surface when a member is marked to be left out', function () {
+    $subject = '
+namespace App\Surface;
+
+use App\Attributes\Ignore;
+
+class Marked
+{
+    %s
+    public string $name = "marked";
+
+    %s
+    public function label(): string
+    {
+        return "label";
+    }
+}';
+
+    $plain = createPhpFixture(sprintf($subject, '', ''));
+    $ignoredProperty = createPhpFixture(sprintf($subject, '#[Ignore]', ''));
+    $ignoredMethod = createPhpFixture(sprintf($subject, '', '#[Ignore]'));
+
+    $before = surfaceHashOf($plain);
+
+    expect(surfaceHashOf($ignoredProperty))->not->toBe($before);
+    expect(surfaceHashOf($ignoredMethod))->not->toBe($before);
+
+    unlink($plain);
+    unlink($ignoredProperty);
+    unlink($ignoredMethod);
+});


### PR DESCRIPTION
Editing one file re-analysed everything that could reach it, which on a large application is most of the cache, and almost all of that work produced identical results. Each entry recorded the full transitive closure of its dependencies and was validated by stat'ing that list, so a change anywhere below a file invalidated everything above it.

An entry now records only the files it reached itself, each with a hash of what that file exposes: its classes, methods, parameters, return types, properties, constants and imports. A dependency that changed gets analysed to see whether the change reached its surface, and if it did not, everything that named it still stands. Editing a method body therefore re-analyses that file and nothing else. The hashes and edges live in a small record beside each entry, so validity is decided without unserializing anything.

Settling cycles is narrower too. It used to re-analyse every member of a closed cycle; it now takes the members that gave up on a file themselves, and reaches further only where a surface actually moved.

Editing a central model drops from tens of seconds to a couple, and the cache to roughly a fifth of its size. Cold and warm builds are unchanged or slightly faster.

Ignore markers are part of the surface, since marking a member changes what dependents can read. Entries and records carry a schema version, bumped here, so the first build after upgrading is a cold one.

`benchmarks/cache` gains `determinism.sh`, `timeit.sh` and `surfacedump.php`, `shapesweep.sh` gains a body-only edit shape, and all of them can be pointed at any application with `SURVEYOR_BENCH_APP`. Warm output matches cold across every shape of source change, and analysing the same tree twice gives identical surfaces.
