### PR TITLE
Guard unary minus against non-numeric types

### DIFF
--- a/src/NodeResolvers/Expr/UnaryMinus.php
+++ b/src/NodeResolvers/Expr/UnaryMinus.php
@@ -4,6 +4,9 @@ namespace Laravel\Surveyor\NodeResolvers\Expr;
 
 use Laravel\Surveyor\NodeResolvers\AbstractResolver;
 use Laravel\Surveyor\Types\Contracts\MultiType;
+use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
+use Laravel\Surveyor\Types\FloatType;
+use Laravel\Surveyor\Types\IntType;
 use Laravel\Surveyor\Types\Type;
 use PhpParser\Node;
 
@@ -14,15 +17,27 @@ class UnaryMinus extends AbstractResolver
         $result = $this->from($node->expr);
 
         if ($result instanceof MultiType) {
-            return Type::union(...array_map(fn ($type) => $type->value * -1, $result->types));
+            return Type::union(...array_map(
+                fn ($type) => $this->negate($type),
+                $result->types,
+            ));
         }
 
-        if (! property_exists($result, 'value') || $result->value === null) {
-            return $result;
+        return $this->negate($result);
+    }
+
+    protected function negate(?TypeContract $type): ?TypeContract
+    {
+        if (! $type instanceof IntType && ! $type instanceof FloatType) {
+            return $type;
         }
 
-        $type = get_class($result);
+        if ($type->value === null) {
+            return $type;
+        }
 
-        return new $type($result->value * -1);
+        $class = $type::class;
+
+        return new $class($type->value * -1);
     }
 }

--- a/tests/Unit/Resolvers/UnaryMinusTest.php
+++ b/tests/Unit/Resolvers/UnaryMinusTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Laravel\Surveyor\Analyzer\AnalyzedCache;
+use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Debug\Debug;
+use Laravel\Surveyor\Types\ArrayType;
+use Laravel\Surveyor\Types\FloatType;
+use Laravel\Surveyor\Types\IntType;
+use Laravel\Surveyor\Types\UnionType;
+
+uses()->group('integration');
+
+beforeEach(function () {
+    AnalyzedCache::clear();
+    Debug::$throw = true;
+});
+
+afterEach(function () {
+    AnalyzedCache::clear();
+    Debug::$throw = false;
+});
+
+function unaryMinusReturnType(string $expression)
+{
+    $fixture = createPhpFixture("
+namespace App;
+
+class UnaryMinusSubject
+{
+    public function test()
+    {
+        {$expression}
+    }
+}
+");
+
+    return app(Analyzer::class)
+        ->analyze($fixture)
+        ->result()
+        ->getMethod('test')
+        ->returnType();
+}
+
+it('negates an integer', function () {
+    $returnType = unaryMinusReturnType('$x = 5; return -$x;');
+
+    expect($returnType)->toBeInstanceOf(IntType::class);
+    expect($returnType->value)->toBe(-5);
+});
+
+it('negates a float', function () {
+    $returnType = unaryMinusReturnType('$x = 1.5; return -$x;');
+
+    expect($returnType)->toBeInstanceOf(FloatType::class);
+    expect($returnType->value)->toBe(-1.5);
+});
+
+it('negates the numeric members of a union and leaves the rest alone', function () {
+    $returnType = unaryMinusReturnType('$x = rand(0, 1) ? [1, 2] : 5; return -$x;');
+
+    expect($returnType)->toBeInstanceOf(UnionType::class);
+    expect($returnType->types)->toHaveCount(2);
+    expect($returnType->types[0])->toBeInstanceOf(ArrayType::class);
+    expect($returnType->types[1])->toBeInstanceOf(IntType::class);
+    expect($returnType->types[1]->value)->toBe(-5);
+});


### PR DESCRIPTION
Negating a union resolved every member without checking it was a number, so a union carrying an array or a string threw a TypeError. In production Debug caught it and the type quietly became mixed, which is why nothing ever surfaced.

The scalar path already had a guard, but it only checked for a `value` property, which strings, bools, classes and arrays all have. Both paths now share a `negate()` helper that only negates IntType and FloatType and hands anything else back untouched.
