### PR TITLE
Infer trans() return types from the key argument

### DIFF
--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -6,6 +6,7 @@ use DateInterval;
 use DatePeriod;
 use DateTimeInterface;
 use Exception;
+use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
@@ -16,6 +17,8 @@ use Laravel\Surveyor\Support\Util;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
+use Laravel\Surveyor\Types\MixedType;
+use Laravel\Surveyor\Types\NullType;
 use Laravel\Surveyor\Types\TemplateTagType;
 use Laravel\Surveyor\Types\Type;
 use Laravel\Surveyor\Types\UnionType;
@@ -94,8 +97,44 @@ class Reflector
             'compact' => $this->handleFunctionCompact($node),
             'app' => $this->handleFunctionApp($node),
             'get_class_vars' => $this->handleFunctionGetClassVars($node),
+            'trans' => $this->handleFunctionTrans($node),
             default => null,
         };
+    }
+
+    protected function handleFunctionTrans(?CallLike $node): ?array
+    {
+        if ($node === null) {
+            return null;
+        }
+
+        $key = Type::null();
+
+        foreach ($node->getArgs() as $index => $arg) {
+            if ($arg->unpack) {
+                return null;
+            }
+
+            if ($arg->name?->name === 'key' || ($index === 0 && $arg->name === null)) {
+                $key = $this->getNodeResolver()->from($arg->value, $this->scope);
+            }
+        }
+
+        if ($key instanceof NullType) {
+            return [new ClassType(Translator::class)];
+        }
+
+        $types = [Type::array([]), Type::string()];
+
+        foreach ($key instanceof UnionType ? $key->types : [$key] as $type) {
+            if ($type instanceof MixedType || $type instanceof NullType || $type->isNullable()) {
+                $types[] = new ClassType(Translator::class);
+
+                break;
+            }
+        }
+
+        return $types;
     }
 
     protected function handleFunctionArrayMerge(?CallLike $node): ?array

--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -128,9 +128,7 @@ class Reflector
 
         foreach ($key instanceof UnionType ? $key->types : [$key] as $type) {
             if ($type instanceof MixedType || $type instanceof NullType || $type->isNullable()) {
-                $types[] = new ClassType(Translator::class);
-
-                break;
+                return [...$types, new ClassType(Translator::class)];
             }
         }
 

--- a/tests/Unit/Resolvers/TranslationCallTest.php
+++ b/tests/Unit/Resolvers/TranslationCallTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Contracts\Translation\Translator;
+use Laravel\Surveyor\Analyzer\AnalyzedCache;
+use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Types\ArrayType;
+use Laravel\Surveyor\Types\ClassType;
+use Laravel\Surveyor\Types\StringType;
+use Laravel\Surveyor\Types\UnionType;
+
+uses()->group('integration');
+
+beforeEach(fn () => AnalyzedCache::clear());
+afterEach(fn () => AnalyzedCache::clear());
+
+it('resolves translation calls from their key argument', function (string $parameters, string $expression, array $expected) {
+    $class = 'TranslationCalls'.md5($parameters.$expression);
+    $fixture = createPhpFixture("
+namespace App\\Test;
+
+class {$class}
+{
+    public function label({$parameters})
+    {
+        return {$expression};
+    }
+}");
+
+    try {
+        require $fixture;
+
+        $type = app(Analyzer::class)->analyze($fixture)->result()->getMethod('label')->returnType();
+        $types = $type instanceof UnionType ? $type->types : [$type];
+
+        expect(array_map(fn ($member) => $member instanceof ClassType ? $member->resolved() : $member::class, $types))
+            ->toEqualCanonicalizing($expected);
+    } finally {
+        unlink($fixture);
+    }
+})->with([
+    'literal key' => ['', 'trans("messages.greeting")', [ArrayType::class, StringType::class]],
+    'named key' => ['', 'trans(locale: "fr", key: "messages.greeting")', [ArrayType::class, StringType::class]],
+    'string key' => ['string $key', 'trans($key)', [ArrayType::class, StringType::class]],
+    'no key' => ['', 'trans()', [Translator::class]],
+    'null key' => ['', 'trans(null)', [Translator::class]],
+    'omitted named key' => ['', 'trans(locale: "fr")', [Translator::class]],
+    'nullable key' => ['?string $key', 'trans($key)', [Translator::class, ArrayType::class, StringType::class]],
+    'unknown key' => ['mixed $key', 'trans($key)', [Translator::class, ArrayType::class, StringType::class]],
+    'unpacked arguments' => ['array $arguments', 'trans(...$arguments)', [Translator::class, ArrayType::class, StringType::class]],
+]);


### PR DESCRIPTION
`trans('messages.saved')` can return a string or an array, but Surveyor also includes `Translator` in the inferred type. Laravel only returns the translator when the key is null.

The helper now resolves its key argument before choosing the return type. `trans()` and `trans(null)` keep `Translator`; calls with a non-null key get `array|string`. Named arguments work the same way. When the key might be null or cannot be determined, the translator stays in the union.

Six of the nine regression cases fail before the fix. All 42 reflector and resolver tests pass, along with PHPStan and Pint.
