### PR TITLE
Resolve PHPDoc array-key as integer or string

### DIFF
--- a/src/DocBlockResolvers/Type/IdentifierTypeNode.php
+++ b/src/DocBlockResolvers/Type/IdentifierTypeNode.php
@@ -18,6 +18,10 @@ class IdentifierTypeNode extends AbstractResolver
             }
         }
 
+        if ($name === 'array-key') {
+            return Type::union(Type::int(), Type::string());
+        }
+
         return Type::from($this->scope->getUse($name));
     }
 }

--- a/tests/Unit/DocBlockResolvers/IdentifierTypeNodeTest.php
+++ b/tests/Unit/DocBlockResolvers/IdentifierTypeNodeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Laravel\Surveyor\Analysis\Scope;
+use Laravel\Surveyor\Parser\DocBlockParser;
+use Laravel\Surveyor\Types\ArrayShapeType;
+use Laravel\Surveyor\Types\IntType;
+use Laravel\Surveyor\Types\MixedType;
+use Laravel\Surveyor\Types\StringType;
+use Laravel\Surveyor\Types\UnionType;
+
+beforeEach(function () {
+    $this->parser = app(DocBlockParser::class);
+    $this->parser->setScope(new Scope);
+});
+
+it('resolves array-key as integer or string', function () {
+    [$type] = $this->parser->parseReturn('/** @return array-key */');
+
+    expect($type)->toEqual(new UnionType([new IntType, new StringType]));
+});
+
+it('resolves array-key in generic arrays and template bounds', function (string $keyType) {
+    $docBlock = "/**\n * @template TKey of array-key\n * @return array<{$keyType}, mixed>\n */";
+    $this->parser->parseTemplateTags($docBlock);
+
+    [$type] = $this->parser->parseReturn($docBlock);
+
+    expect($type)->toEqual(new ArrayShapeType(
+        new UnionType([new IntType, new StringType]),
+        new MixedType,
+    ));
+})->with(['array-key', 'TKey']);
+
+it('preserves a quoted array-key string literal', function () {
+    [$type] = $this->parser->parseReturn("/** @return 'array-key' */");
+
+    expect($type)->toEqual(new StringType('array-key'));
+});


### PR DESCRIPTION
The PHPDoc resolver treats an unquoted `array-key` as a string literal. As a result, `array<array-key, T>` and template bounds carry the wrong key type into the analyzer.

Resolve the builtin to `int|string`, while leaving a quoted `'array-key'` unchanged. The change uses the existing union types and does not alter template substitution.

The tests cover the builtin, generic array keys, a template bound and the quoted literal. All 390 tests pass on Laravel 12.69.2, with two existing skips. PHPStan and Pint pass as well.
