### PR TITLE
Preserve resource payloads through Inertia and method calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/contracts": "^12.0|^13.0",
         "illuminate/database": "^12.0|^13.0",
         "illuminate/filesystem": "^12.0|^13.0",
-        "illuminate/http": "^12.0|^13.0",
+        "illuminate/http": "^12.45.2|^13.0",
         "illuminate/support": "^12.0|^13.0",
         "illuminate/validation": "^12.0|^13.0",
         "nikic/php-parser": "^5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3ff9b781d97fdb302950929368acd73",
+    "content-hash": "a82ccc347bb56d297f044b86e756c3f9",
     "packages": [
         {
             "name": "brick/math",

--- a/src/Analyzer/ResourceAnalyzer.php
+++ b/src/Analyzer/ResourceAnalyzer.php
@@ -3,6 +3,7 @@
 namespace Laravel\Surveyor\Analyzer;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Http\Resources\JsonApi\JsonApiResource;
@@ -157,6 +158,7 @@ class ResourceAnalyzer
             isCollection: true,
             wrap: $response->wrap,
             additional: $response->additional,
+            responseClass: AnonymousResourceCollection::class,
         ) : $response;
     }
 

--- a/src/Analyzer/ResourceAnalyzer.php
+++ b/src/Analyzer/ResourceAnalyzer.php
@@ -18,6 +18,7 @@ use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 use Laravel\Surveyor\Types\Entities\JsonApiResourceResponse;
 use Laravel\Surveyor\Types\Entities\ResourceResponse;
 use Laravel\Surveyor\Types\Type;
+use Laravel\Surveyor\Types\UnionType;
 use ReflectionClass;
 use ReflectionNamedType;
 use Throwable;
@@ -166,7 +167,7 @@ class ResourceAnalyzer
         if ($result->hasMethod('toArray')) {
             $returnType = $result->getMethod('toArray')->returnType();
 
-            if ($returnType instanceof ArrayType) {
+            if ($returnType instanceof ArrayType || ($returnType instanceof UnionType && collect($returnType->types)->every(fn ($type) => $type instanceof ArrayType))) {
                 return $returnType;
             }
         }

--- a/src/Analyzer/ResourceAnalyzer.php
+++ b/src/Analyzer/ResourceAnalyzer.php
@@ -100,7 +100,7 @@ class ResourceAnalyzer
         $this->responses[$resource] = new ResourceResponse(
             resourceClass: $resource,
             data: $data,
-            isCollection: $this->isResourceCollection($resource),
+            isCollection: $this->needsCollectionWrapping($resource),
             wrap: $wrap,
             additional: $additional,
         );
@@ -132,38 +132,35 @@ class ResourceAnalyzer
             return null;
         }
 
-        // Reuse the response cached during Phase B if analysis already produced one
-        if ($existing = $this->responses[$resourceClass] ?? null) {
-            if ($isCollection && ! $existing->isCollection) {
-                return new ResourceResponse(
-                    resourceClass: $existing->resourceClass,
-                    data: $existing->data,
-                    isCollection: true,
-                    wrap: $existing->wrap,
-                    additional: $existing->additional,
-                );
+        // Reuse the response cached during Phase B if analysis already produced one.
+        $response = $this->responses[$resourceClass] ?? null;
+
+        if ($response === null) {
+            $data = $this->extractDataShape($resourceClass, $result);
+
+            if ($data === null) {
+                return null;
             }
 
-            return $existing;
+            $response = new ResourceResponse(
+                resourceClass: $resourceClass,
+                data: $data,
+                isCollection: $this->needsCollectionWrapping($resourceClass),
+                wrap: $this->resolveWrapKey($resourceClass),
+                additional: $this->resolveWithMethod($result),
+            );
         }
 
-        // Fallback: try to extract the resource shape directly
-        $data = $this->extractDataShape($resourceClass, $result);
-
-        if (! $data) {
-            return null;
-        }
-
-        return new ResourceResponse(
-            resourceClass: $resourceClass,
-            data: $data,
-            isCollection: $isCollection || $this->isResourceCollection($resourceClass),
-            wrap: $this->resolveWrapKey($resourceClass),
-            additional: $this->resolveWithMethod($result),
-        );
+        return $isCollection ? new ResourceResponse(
+            resourceClass: $response->resourceClass,
+            data: $response->payload(),
+            isCollection: true,
+            wrap: $response->wrap,
+            additional: $response->additional,
+        ) : $response;
     }
 
-    public function resolveDataMethod(string $resource): ?ReflectionMethod
+    protected function resolveDataMethod(string $resource): ?ReflectionMethod
     {
         $reflection = new ReflectionClass($resource);
 
@@ -190,32 +187,18 @@ class ResourceAnalyzer
             return null;
         }
 
-        if ($result->hasMethod($method->getName())) {
-            $returnType = $result->getMethod($method->getName())->returnType();
-
-            return $returnType instanceof ArrayType || ($returnType instanceof UnionType && collect($returnType->types)->every(fn ($type) => $type instanceof ArrayType))
-                ? $returnType
-                : null;
-        }
-
-        if ($method->getDeclaringClass()->getName() !== ResourceCollection::class) {
-            return null;
-        }
-
-        // For ResourceCollection without toArray, the shape is an array of the collected resource
-        if ($this->isResourceCollection($resource)) {
+        if ($method->getDeclaringClass()->getName() === ResourceCollection::class) {
             $collectedResource = $this->resolveCollectedResource($resource);
 
-            if ($collectedResource) {
-                $innerResponse = $this->buildResourceResponse($collectedResource);
-
-                if ($innerResponse) {
-                    return $innerResponse->data;
-                }
-            }
+            return $collectedResource ? $this->buildResourceResponse($collectedResource)?->payload() : null;
         }
 
-        return null;
+        $returnType = $result->getMethod($method->getName())?->returnType();
+        $types = $returnType instanceof UnionType ? $returnType->types : [$returnType];
+
+        return collect($types)->every(fn ($type) => $type !== null && Type::is($type, ArrayType::class, ArrayShapeType::class))
+            ? $returnType
+            : null;
     }
 
     protected function resolveModelClass(string $resource, ClassLikeResult $result, Scope $scope): ?string
@@ -344,9 +327,9 @@ class ResourceAnalyzer
         return null;
     }
 
-    protected function isResourceCollection(string $resource): bool
+    protected function needsCollectionWrapping(string $resource): bool
     {
-        return is_subclass_of($resource, ResourceCollection::class);
+        return $this->resolveDataMethod($resource)?->getDeclaringClass()->getName() === ResourceCollection::class;
     }
 
     protected function resolveCollectedResource(string $collectionClass): ?string

--- a/src/Analyzer/ResourceAnalyzer.php
+++ b/src/Analyzer/ResourceAnalyzer.php
@@ -20,6 +20,7 @@ use Laravel\Surveyor\Types\Entities\ResourceResponse;
 use Laravel\Surveyor\Types\Type;
 use Laravel\Surveyor\Types\UnionType;
 use ReflectionClass;
+use ReflectionMethod;
 use ReflectionNamedType;
 use Throwable;
 
@@ -72,7 +73,7 @@ class ResourceAnalyzer
     }
 
     /**
-     * Phase B: After toArray() has been walked, extract the resolved data shape
+     * Phase B: After resource methods have been walked, extract the resolved data shape
      * and store resource metadata on the ClassLikeResult.
      *
      * Called on class EXIT (after method bodies have been walked).
@@ -87,7 +88,7 @@ class ResourceAnalyzer
             return;
         }
 
-        $data = $this->extractToArrayShape($resource, $result);
+        $data = $this->extractDataShape($resource, $result);
 
         if (! $data) {
             return;
@@ -146,8 +147,8 @@ class ResourceAnalyzer
             return $existing;
         }
 
-        // Fallback: try to extract toArray shape directly
-        $data = $this->extractToArrayShape($resourceClass, $result);
+        // Fallback: try to extract the resource shape directly
+        $data = $this->extractDataShape($resourceClass, $result);
 
         if (! $data) {
             return null;
@@ -162,14 +163,43 @@ class ResourceAnalyzer
         );
     }
 
-    protected function extractToArrayShape(string $resource, ClassLikeResult $result): ?TypeContract
+    public function resolveDataMethod(string $resource): ?ReflectionMethod
     {
-        if ($result->hasMethod('toArray')) {
-            $returnType = $result->getMethod('toArray')->returnType();
+        $reflection = new ReflectionClass($resource);
 
-            if ($returnType instanceof ArrayType || ($returnType instanceof UnionType && collect($returnType->types)->every(fn ($type) => $type instanceof ArrayType))) {
-                return $returnType;
+        foreach (['resolve', 'resolveResourceData', 'toAttributes', 'toArray'] as $method) {
+            $reflected = $reflection->getMethod($method);
+
+            if ($reflected->getDeclaringClass()->getName() !== JsonResource::class) {
+                return $reflected;
             }
+
+            if ($method === 'toAttributes' && $reflection->hasProperty('attributes')) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    protected function extractDataShape(string $resource, ClassLikeResult $result): ?TypeContract
+    {
+        $method = $this->resolveDataMethod($resource);
+
+        if ($method === null) {
+            return null;
+        }
+
+        if ($result->hasMethod($method->getName())) {
+            $returnType = $result->getMethod($method->getName())->returnType();
+
+            return $returnType instanceof ArrayType || ($returnType instanceof UnionType && collect($returnType->types)->every(fn ($type) => $type instanceof ArrayType))
+                ? $returnType
+                : null;
+        }
+
+        if ($method->getDeclaringClass()->getName() !== ResourceCollection::class) {
+            return null;
         }
 
         // For ResourceCollection without toArray, the shape is an array of the collected resource

--- a/src/NodeResolvers/Expr/StaticCall.php
+++ b/src/NodeResolvers/Expr/StaticCall.php
@@ -125,7 +125,7 @@ class StaticCall extends AbstractResolver
 
         if (
             $class->value === 'Inertia\Inertia'
-            && in_array($method, ['defer', 'optional', 'lazy', 'always', 'merge'], true)
+            && in_array($method, ['defer', 'optional', 'lazy', 'always', 'merge', 'scroll'], true)
         ) {
             return true;
         }
@@ -175,14 +175,15 @@ class StaticCall extends AbstractResolver
             ];
         }
 
-        if (in_array($method, ['defer', 'optional', 'lazy', 'always', 'merge'], true)) {
+        if (in_array($method, ['defer', 'optional', 'lazy', 'always', 'merge', 'scroll'], true)) {
             $args = $node->getArgs();
 
             if (empty($args)) {
                 return [Type::mixed()];
             }
 
-            $type = $this->resolveClosureReturnType($args[0]->value) ?? Type::mixed();
+            $type = $this->resolveClosureReturnType($args[0]->value)
+                ?? ($method === 'scroll' ? $this->from($args[0]->value) : Type::mixed());
 
             if (in_array($method, ['defer', 'optional', 'lazy'], true)) {
                 $type->optional();

--- a/src/NodeResolvers/Shared/ResolvesMethodCalls.php
+++ b/src/NodeResolvers/Shared/ResolvesMethodCalls.php
@@ -3,10 +3,7 @@
 namespace Laravel\Surveyor\NodeResolvers\Shared;
 
 use Illuminate\Http\Request;
-use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
-use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Support\Facades\Request as RequestFacade;
-use Laravel\Surveyor\Analyzer\ResourceAnalyzer;
 use Laravel\Surveyor\Concerns\LazilyLoadsDependencies;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
@@ -66,17 +63,7 @@ trait ResolvesMethodCalls
         }
 
         if ($var instanceof ResourceResponse && $methodName->value === 'resolve') {
-            $resourceClass = $var->isCollection && ! is_subclass_of($var->resolved(), ResourceCollection::class)
-                ? AnonymousResourceCollection::class
-                : $var->resolved();
-
-            $method = app(ResourceAnalyzer::class)->resolveDataMethod($resourceClass);
-
-            if ($method !== null && $method->getName() !== 'resolve') {
-                return $method->getDeclaringClass()->getName() === ResourceCollection::class
-                    ? Type::arrayShape(Type::union(Type::int(), Type::string()), $var->data)
-                    : clone $var->data;
-            }
+            return $var->payload();
         }
 
         $returned = Type::union(

--- a/src/NodeResolvers/Shared/ResolvesMethodCalls.php
+++ b/src/NodeResolvers/Shared/ResolvesMethodCalls.php
@@ -4,9 +4,9 @@ namespace Laravel\Surveyor\NodeResolvers\Shared;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
-use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Support\Facades\Request as RequestFacade;
+use Laravel\Surveyor\Analyzer\ResourceAnalyzer;
 use Laravel\Surveyor\Concerns\LazilyLoadsDependencies;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
@@ -15,7 +15,6 @@ use Laravel\Surveyor\Types\MixedType;
 use Laravel\Surveyor\Types\StringType;
 use Laravel\Surveyor\Types\Type;
 use PhpParser\Node;
-use ReflectionMethod;
 
 trait ResolvesMethodCalls
 {
@@ -71,8 +70,10 @@ trait ResolvesMethodCalls
                 ? AnonymousResourceCollection::class
                 : $var->resolved();
 
-            if ((new ReflectionMethod($resourceClass, 'resolve'))->getDeclaringClass()->getName() === JsonResource::class) {
-                return (new ReflectionMethod($resourceClass, 'toArray'))->getDeclaringClass()->getName() === ResourceCollection::class
+            $method = app(ResourceAnalyzer::class)->resolveDataMethod($resourceClass);
+
+            if ($method !== null && $method->getName() !== 'resolve') {
+                return $method->getDeclaringClass()->getName() === ResourceCollection::class
                     ? Type::arrayShape(Type::union(Type::int(), Type::string()), $var->data)
                     : clone $var->data;
             }

--- a/src/NodeResolvers/Shared/ResolvesMethodCalls.php
+++ b/src/NodeResolvers/Shared/ResolvesMethodCalls.php
@@ -3,14 +3,19 @@
 namespace Laravel\Surveyor\NodeResolvers\Shared;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Support\Facades\Request as RequestFacade;
 use Laravel\Surveyor\Concerns\LazilyLoadsDependencies;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
+use Laravel\Surveyor\Types\Entities\ResourceResponse;
 use Laravel\Surveyor\Types\MixedType;
 use Laravel\Surveyor\Types\StringType;
 use Laravel\Surveyor\Types\Type;
 use PhpParser\Node;
+use ReflectionMethod;
 
 trait ResolvesMethodCalls
 {
@@ -59,6 +64,18 @@ trait ResolvesMethodCalls
 
         if (in_array($methodName->value, static::$conditionalMethods) && $this->isJsonResource($var)) {
             return $this->resolveResourceConditional($var, $methodName->value, $node);
+        }
+
+        if ($var instanceof ResourceResponse && $methodName->value === 'resolve') {
+            $resourceClass = $var->isCollection && ! is_subclass_of($var->resolved(), ResourceCollection::class)
+                ? AnonymousResourceCollection::class
+                : $var->resolved();
+
+            if ((new ReflectionMethod($resourceClass, 'resolve'))->getDeclaringClass()->getName() === JsonResource::class) {
+                return (new ReflectionMethod($resourceClass, 'toArray'))->getDeclaringClass()->getName() === ResourceCollection::class
+                    ? Type::arrayShape(Type::union(Type::int(), Type::string()), $var->data)
+                    : clone $var->data;
+            }
         }
 
         $returned = Type::union(

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -3,9 +3,12 @@
 namespace Laravel\Surveyor\Parser;
 
 use Laravel\Surveyor\Analysis\Scope;
+use Laravel\Surveyor\Analyzed\ClassLikeResult;
+use Laravel\Surveyor\Analyzed\MethodResult;
 use Laravel\Surveyor\Resolvers\NodeResolver;
 use Laravel\Surveyor\Support\Markers;
 use Laravel\Surveyor\Visitors\TypeResolver;
+use PhpParser\Node;
 use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
@@ -79,6 +82,32 @@ class Parser
         $traverser->traverse($this->parser->parse($code));
 
         return $typeResolver->scope();
+    }
+
+    public function parseMethod(ReflectionMethod $method, Scope $scope): ?MethodResult
+    {
+        $result = $scope->result();
+        $path = $method->getFileName();
+
+        if (! $result instanceof ClassLikeResult || $path === false) {
+            return null;
+        }
+
+        $nodes = $this->parseFile($path);
+        $nodes = (new NodeTraverser(new NameResolver(null, ['preserveOriginalNames' => true])))->traverse($nodes);
+        $class = $this->nodeFinder->findFirst($nodes, fn (Node $node) => $node instanceof Node\Stmt\ClassLike
+            && $node->namespacedName?->toString() === $method->getDeclaringClass()->getName());
+        $node = $class instanceof Node\Stmt\ClassLike ? $class->getMethod($method->getName()) : null;
+
+        if ($node === null) {
+            return null;
+        }
+
+        $typeResolver = new TypeResolver($this->resolver);
+        $typeResolver->setScope($scope);
+        (new NodeTraverser($typeResolver))->traverse([$node]);
+
+        return $result->getMethod($method->getName());
     }
 
     public function nodeFinder()

--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -455,11 +455,9 @@ class Reflector
                 if ($analyzedMethod !== null) {
                     $inferred = $analyzedMethod->returnType();
 
-                    foreach ($inferred instanceof UnionType ? $inferred->types : [$inferred] as $candidate) {
-                        if ($this->containsResourceType($candidate)) {
-                            $returnTypes[] = $candidate;
-                            $returnTypes = [Type::collapse(Type::union(...$returnTypes))];
-                        }
+                    if ($this->containsResourceType($inferred)) {
+                        $returnTypes[] = $inferred;
+                        $returnTypes = [Type::collapse(Type::union(...$returnTypes))];
                     }
                 }
             }

--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -9,10 +9,13 @@ use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Laravel\Surveyor\Analysis\Scope;
+use Laravel\Surveyor\Analyzed\ClassLikeResult;
 use Laravel\Surveyor\Concerns\LazilyLoadsDependencies;
 use Laravel\Surveyor\Debug\Debug;
 use Laravel\Surveyor\Support\Util;
+use Laravel\Surveyor\Types\ArrayShapeType;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
@@ -43,6 +46,8 @@ class Reflector
     protected array $cachedFunctions = [];
 
     protected array $cachedMacros = [];
+
+    protected array $resolvingMethods = [];
 
     /** @var array<string, list<string>> */
     protected array $cachedTraitUseDocBlocks = [];
@@ -360,8 +365,10 @@ class Reflector
 
             $returnTypes = [];
 
-            if ($reflection->hasMethod($method)) {
-                $methodReflection = $reflection->getMethod($method);
+            $methodReflection = $reflection->hasMethod($method) ? $reflection->getMethod($method) : null;
+
+            if ($methodReflection !== null) {
+                $method = $methodReflection->getName();
 
                 if ($methodReflection->hasReturnType()) {
                     $returnTypes[] = $this->returnType($methodReflection->getReturnType());
@@ -417,6 +424,46 @@ class Reflector
                 }
             }
 
+            // Resource class names omit their response data. Preserve the analyzed
+            // shape, including when its helper has not been visited yet, without
+            // replacing the generic contracts of unrelated methods.
+            $methodScope = $this->scope;
+
+            while ($methodScope && ! $methodScope->result() instanceof ClassLikeResult) {
+                $methodScope = $methodScope->parent();
+            }
+
+            if ($methodScope?->result()?->name() === $reflection->getName() && $methodReflection !== null) {
+                $analyzedMethod = $methodScope->result()->getMethod($method);
+                $key = $reflection->getName().'::'.$method;
+
+                if ($analyzedMethod === null && $this->containsResourceType(Type::union(...$returnTypes))
+                    && ! isset($this->resolvingMethods[$key])
+                    && $methodReflection->getDeclaringClass()->getName() === $reflection->getName()
+                    && $methodReflection->getFileName() !== false) {
+                    $this->resolvingMethods[$key] = true;
+                    $currentScope = $this->scope;
+
+                    try {
+                        $analyzedMethod = $this->getParser()->parseMethod($methodReflection, $methodScope);
+                    } finally {
+                        unset($this->resolvingMethods[$key]);
+                        $this->setScope($currentScope);
+                    }
+                }
+
+                if ($analyzedMethod !== null) {
+                    $inferred = $analyzedMethod->returnType();
+
+                    foreach ($inferred instanceof UnionType ? $inferred->types : [$inferred] as $candidate) {
+                        if ($this->containsResourceType($candidate)) {
+                            $returnTypes[] = $candidate;
+                            $returnTypes = [Type::collapse(Type::union(...$returnTypes))];
+                        }
+                    }
+                }
+            }
+
             if (count($returnTypes) > 0) {
                 return $returnTypes;
             }
@@ -433,6 +480,28 @@ class Reflector
                 $this->setScope($scopeToRestore);
             }
         }
+    }
+
+    protected function containsResourceType(TypeContract $type): bool
+    {
+        if ($type instanceof ClassType && is_a($type->resolved(), JsonResource::class, true)) {
+            return true;
+        }
+
+        $types = match (true) {
+            $type instanceof UnionType => $type->types,
+            $type instanceof ArrayType => $type->value,
+            $type instanceof ArrayShapeType => [$type->valueType],
+            default => [],
+        };
+
+        foreach ($types as $inner) {
+            if ($this->containsResourceType($inner)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -439,8 +439,7 @@ class Reflector
 
                 if ($analyzedMethod === null && $this->containsResourceType(Type::union(...$returnTypes))
                     && ! isset($this->resolvingMethods[$key])
-                    && $methodReflection->getDeclaringClass()->getName() === $reflection->getName()
-                    && $methodReflection->getFileName() !== false) {
+                    && $methodReflection->getDeclaringClass()->getName() === $reflection->getName()) {
                     $this->resolvingMethods[$key] = true;
                     $currentScope = $this->scope;
 
@@ -452,13 +451,11 @@ class Reflector
                     }
                 }
 
-                if ($analyzedMethod !== null) {
-                    $inferred = $analyzedMethod->returnType();
+                $inferred = $analyzedMethod?->returnType();
 
-                    if ($this->containsResourceType($inferred)) {
-                        $returnTypes[] = $inferred;
-                        $returnTypes = [Type::collapse(Type::union(...$returnTypes))];
-                    }
+                if ($inferred !== null && $this->containsResourceType($inferred)) {
+                    $returnTypes[] = $inferred;
+                    $returnTypes = [Type::collapse(Type::union(...$returnTypes))];
                 }
             }
 

--- a/src/Types/Entities/ResourceResponse.php
+++ b/src/Types/Entities/ResourceResponse.php
@@ -3,6 +3,7 @@
 namespace Laravel\Surveyor\Types\Entities;
 
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Resources\Json\ResourceCollection;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 
@@ -29,6 +30,6 @@ class ResourceResponse extends ClassType
     {
         return $type::class === ClassType::class
             && ($this->resolved() === $type->resolved()
-                || ($this->isCollection && $type->resolved() === AnonymousResourceCollection::class));
+                || ($this->isCollection && ! is_a($this->resolved(), ResourceCollection::class, true) && $type->resolved() === AnonymousResourceCollection::class));
     }
 }

--- a/src/Types/Entities/ResourceResponse.php
+++ b/src/Types/Entities/ResourceResponse.php
@@ -6,9 +6,13 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
+use Laravel\Surveyor\Types\Type;
 
 class ResourceResponse extends ClassType
 {
+    /**
+     * @param  bool  $isCollection  Whether data describes each element rather than the complete payload.
+     */
     public function __construct(
         public readonly string $resourceClass,
         public readonly TypeContract $data,
@@ -17,6 +21,16 @@ class ResourceResponse extends ClassType
         public readonly ?TypeContract $additional = null,
     ) {
         parent::__construct($resourceClass);
+    }
+
+    /**
+     * The resolved data before response wrapping and additional fields.
+     */
+    public function payload(): TypeContract
+    {
+        return $this->isCollection
+            ? Type::arrayShape(Type::union(Type::int(), Type::string()), $this->data)
+            : clone $this->data;
     }
 
     public function id(): string

--- a/src/Types/Entities/ResourceResponse.php
+++ b/src/Types/Entities/ResourceResponse.php
@@ -2,8 +2,6 @@
 
 namespace Laravel\Surveyor\Types\Entities;
 
-use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
-use Illuminate\Http\Resources\Json\ResourceCollection;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 use Laravel\Surveyor\Types\Type;
@@ -19,8 +17,9 @@ class ResourceResponse extends ClassType
         public readonly bool $isCollection = false,
         public readonly ?string $wrap = 'data',
         public readonly ?TypeContract $additional = null,
+        ?string $responseClass = null,
     ) {
-        parent::__construct($resourceClass);
+        parent::__construct($responseClass ?? $resourceClass);
     }
 
     /**
@@ -43,7 +42,6 @@ class ResourceResponse extends ClassType
     public function isMoreSpecificThan(TypeContract $type): bool
     {
         return $type::class === ClassType::class
-            && ($this->resolved() === $type->resolved()
-                || ($this->isCollection && ! is_a($this->resolved(), ResourceCollection::class, true) && $type->resolved() === AnonymousResourceCollection::class));
+            && $this->resolved() === $type->resolved();
     }
 }

--- a/src/Types/Entities/ResourceResponse.php
+++ b/src/Types/Entities/ResourceResponse.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Surveyor\Types\Entities;
 
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 
@@ -22,5 +23,12 @@ class ResourceResponse extends ClassType
         $id = $this->resourceClass.'::'.$this->data->id();
 
         return $this->isCollection ? $id.'[]' : $id;
+    }
+
+    public function isMoreSpecificThan(TypeContract $type): bool
+    {
+        return $type::class === ClassType::class
+            && ($this->resolved() === $type->resolved()
+                || ($this->isCollection && $type->resolved() === AnonymousResourceCollection::class));
     }
 }

--- a/src/Types/UnionType.php
+++ b/src/Types/UnionType.php
@@ -57,7 +57,7 @@ class UnionType extends AbstractType implements Contracts\CollapsibleType, Contr
 
         foreach ($types as $type) {
             foreach ($type->value as $key => $value) {
-                $value->required(in_array($key, $requiredKeys));
+                $value = (clone $value)->required(in_array($key, $requiredKeys));
 
                 $newData[$key] ??= [];
                 $newData[$key][] = $value;

--- a/src/Visitors/TypeResolver.php
+++ b/src/Visitors/TypeResolver.php
@@ -23,6 +23,11 @@ class TypeResolver extends NodeVisitorAbstract
         return $this->scope;
     }
 
+    public function setScope(Scope $scope): void
+    {
+        $this->scope = $scope;
+    }
+
     public function newScope(string $path)
     {
         $this->scope = new Scope;

--- a/tests/Unit/Analyzer/ResourceAnalyzerTest.php
+++ b/tests/Unit/Analyzer/ResourceAnalyzerTest.php
@@ -2,6 +2,7 @@
 
 use App\Http\Resources\ChildApiResource;
 use App\Http\Resources\ConditionalLabelResource;
+use App\Http\Resources\ConditionalShapeResource;
 use App\Http\Resources\CustomWrapResource;
 use App\Http\Resources\PlainLabelResource;
 use App\Http\Resources\PostResource;
@@ -10,12 +11,14 @@ use App\Http\Resources\UserCollection;
 use App\Http\Resources\UserResource;
 use App\Http\Resources\WhenLookupResource;
 use App\Models\Tag;
+use Illuminate\Http\Request;
 use Laravel\Surveyor\Analyzer\AnalyzedCache;
 use Laravel\Surveyor\Analyzer\Analyzer;
 use Laravel\Surveyor\Analyzer\ResourceAnalyzer;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\Entities\ResourceResponse;
 use Laravel\Surveyor\Types\StringType;
+use Laravel\Surveyor\Types\Type;
 
 uses()->group('integration');
 
@@ -28,6 +31,112 @@ afterEach(function () {
 });
 
 describe('ResourceAnalyzer', function () {
+    it('preserves resolved resource payloads without their response wrapping', function (string $expression, bool $isCollection) {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use Illuminate\\Http\\Request;
+use App\\Http\\Resources\\ConditionalShapeResource;
+
+class ResourceController
+{
+    public function index(Request $request)
+    {
+        return '.$expression.';
+    }
+}');
+
+        try {
+            $result = app(Analyzer::class)->analyze($fixture)->result();
+            $data = Type::union(
+                Type::array(['id' => Type::int(1), 'name' => Type::string('Ada')]),
+                Type::array(['id' => Type::int(1)]),
+            );
+
+            expect($result->getMethod('index')->returnType())->toEqual($isCollection
+                ? Type::arrayShape(Type::union(Type::int(), Type::string()), $data)
+                : Type::array(['id' => Type::int(1), 'name' => Type::string('Ada')->optional()]));
+
+            expect(app(ResourceAnalyzer::class)->buildResourceResponse(ConditionalShapeResource::class)->data)->toEqual($data);
+
+            $request = Request::create('/');
+            $resolved = $isCollection
+                ? ConditionalShapeResource::collection(['featured' => null])->resolve($request)
+                : (new ConditionalShapeResource(null))->resolve($request);
+
+            expect($resolved)->toBe($isCollection ? ['featured' => ['id' => 1]] : ['id' => 1]);
+        } finally {
+            unlink($fixture);
+        }
+    })->with([
+        'resource with null data' => ['(new ConditionalShapeResource(null))->resolve($request)', false],
+        'resource collection' => ['ConditionalShapeResource::collection([])->resolve($request)', true],
+    ]);
+
+    it('respects a resource that overrides resolve instead of returning its toArray shape', function () {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use App\\Http\\Resources\\CustomResolveResource;
+
+class ResourceController
+{
+    public function index()
+    {
+        return (new CustomResolveResource(null))->resolve();
+    }
+}');
+
+        try {
+            $result = app(Analyzer::class)->analyze($fixture)->result();
+
+            expect($result->getMethod('index')->returnType())->toEqual(Type::array(['custom' => Type::int()]));
+        } finally {
+            unlink($fixture);
+        }
+    });
+
+    it('resolves the collection implementation rather than the collected resource override', function (bool $customPayload) {
+        $expression = $customPayload
+            ? '(new CustomPayloadCollection([]))->resolve()'
+            : 'CustomResolveResource::collection([])->resolve()';
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use App\\Http\\Resources\\CustomPayloadCollection;
+use App\\Http\\Resources\\CustomResolveResource;
+
+class ResourceController
+{
+    public function index()
+    {
+        return '.$expression.';
+    }
+}');
+
+        try {
+            $result = app(Analyzer::class)->analyze($fixture)->result();
+
+            expect($result->getMethod('index')->returnType())->toEqual($customPayload
+                ? Type::array(['count' => Type::int(42)])
+                : Type::arrayShape(Type::union(Type::int(), Type::string()), Type::array(['name' => Type::string('Ada')])));
+        } finally {
+            unlink($fixture);
+        }
+    })->with([true, false]);
+
+    it('preserves every toArray return shape for resources and collections', function (bool $isCollection) {
+        $response = app(ResourceAnalyzer::class)->buildResourceResponse(ConditionalShapeResource::class, $isCollection);
+
+        expect($response)->toBeInstanceOf(ResourceResponse::class);
+        expect($response->isCollection)->toBe($isCollection);
+        expect($response->wrap)->toBe('data');
+        expect($response->data)->toEqual(Type::union(
+            Type::array(['id' => Type::int(1), 'name' => Type::string('Ada')]),
+            Type::array(['id' => Type::int(1)]),
+        ));
+    })->with([false, true]);
+
     it('detects resource class and extracts toArray shape', function () {
         $analyzer = app(Analyzer::class);
         $result = $analyzer->analyzeClass(PostResource::class)->result();

--- a/tests/Unit/Analyzer/ResourceAnalyzerTest.php
+++ b/tests/Unit/Analyzer/ResourceAnalyzerTest.php
@@ -7,6 +7,8 @@ use App\Http\Resources\CustomAttributesCollection;
 use App\Http\Resources\CustomPayloadCollection;
 use App\Http\Resources\CustomResolveResource;
 use App\Http\Resources\CustomWrapResource;
+use App\Http\Resources\MappedResourceCollection;
+use App\Http\Resources\MethodCallCollection;
 use App\Http\Resources\PlainLabelResource;
 use App\Http\Resources\PostResource;
 use App\Http\Resources\UnwrappedResource;
@@ -19,9 +21,11 @@ use Illuminate\Http\Resources\Json\JsonResource;
 use Laravel\Surveyor\Analyzer\AnalyzedCache;
 use Laravel\Surveyor\Analyzer\Analyzer;
 use Laravel\Surveyor\Analyzer\ResourceAnalyzer;
+use Laravel\Surveyor\Types\ArrayShapeType;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 use Laravel\Surveyor\Types\Entities\ResourceResponse;
+use Laravel\Surveyor\Types\MixedType;
 use Laravel\Surveyor\Types\StringType;
 use Laravel\Surveyor\Types\Type;
 
@@ -85,6 +89,7 @@ namespace App\\Test;
 use App\\Http\\Resources\\CustomAttributesCollection;
 use App\\Http\\Resources\\CustomPayloadCollection;
 use App\\Http\\Resources\\CustomResolveResource;
+use App\\Http\\Resources\\MethodCallCollection;
 
 class ResourceController
 {
@@ -106,7 +111,7 @@ class ResourceController
     })->with([
         'overridden resolve' => [
             '(new CustomResolveResource(null))->resolve()',
-            fn () => Type::array(['custom' => Type::int()]),
+            fn () => Type::array(['custom' => Type::int(42)]),
             fn () => (new CustomResolveResource(null))->resolve(),
             ['custom' => 42],
         ],
@@ -121,6 +126,24 @@ class ResourceController
             fn () => Type::array(['attributes' => Type::int(42)]),
             fn () => (new CustomAttributesCollection([null]))->resolve(Request::create('/')),
             ['attributes' => 42],
+        ],
+        'native named collection' => [
+            '(new MethodCallCollection([null]))->resolve()',
+            fn () => Type::arrayShape(Type::union(Type::int(), Type::string()), Type::array(['id' => Type::int(1), 'label' => Type::string('Example')])),
+            fn () => (new MethodCallCollection([null]))->resolve(Request::create('/')),
+            [['id' => 1, 'label' => 'Example']],
+        ],
+        'collected native collection' => [
+            'MethodCallCollection::collection([[null]])->resolve()',
+            fn () => Type::arrayShape(Type::union(Type::int(), Type::string()), Type::arrayShape(Type::union(Type::int(), Type::string()), Type::array(['id' => Type::int(1), 'label' => Type::string('Example')]))),
+            fn () => MethodCallCollection::collection([[null]])->resolve(Request::create('/')),
+            [[['id' => 1, 'label' => 'Example']]],
+        ],
+        'collected custom collection' => [
+            'CustomPayloadCollection::collection([[null]])->resolve()',
+            fn () => Type::arrayShape(Type::union(Type::int(), Type::string()), Type::array(['count' => Type::int(42)])),
+            fn () => CustomPayloadCollection::collection([[null]])->resolve(Request::create('/')),
+            [['count' => 42]],
         ],
         'collected resource override' => [
             'CustomResolveResource::collection([null])->resolve()',
@@ -192,6 +215,31 @@ class ResourceController
             false,
         ],
         'inherited resolve override' => [CustomResolveResource::class, '', false],
+    ]);
+
+    it('preserves a mapped collection as its complete generic array payload', function () {
+        $resource = new MappedResourceCollection([null]);
+
+        expect(json_decode(json_encode($resource->resolve(Request::create('/'))), true))->toBe([
+            ['id' => 1, 'label' => 'Example'],
+        ]);
+
+        $response = app(ResourceAnalyzer::class)->buildResourceResponse(MappedResourceCollection::class);
+
+        expect($response)->toBeInstanceOf(ResourceResponse::class)
+            ->and($response->isCollection)->toBeFalse()
+            ->and($response->data)->toBeInstanceOf(ArrayShapeType::class)
+            ->and($response->data->valueType)->toBeInstanceOf(MixedType::class);
+    });
+
+    it('only adds collection wrapping to native collection payloads', function (string $resource, bool $needsWrapping) {
+        $response = app(ResourceAnalyzer::class)->buildResourceResponse($resource);
+
+        expect($response->isCollection)->toBe($needsWrapping);
+    })->with([
+        'native collection' => [MethodCallCollection::class, true],
+        'custom toArray' => [CustomPayloadCollection::class, false],
+        'custom toAttributes' => [CustomAttributesCollection::class, false],
     ]);
 
     it('preserves every toArray return shape for resources and collections', function (bool $isCollection) {
@@ -285,13 +333,13 @@ class ResourceController
         expect($resourceResponse->wrap)->toBe('results');
     });
 
-    it('detects ResourceCollection as collection', function () {
+    it('keeps a custom collection payload without an extra collection wrapper', function () {
         $analyzer = app(Analyzer::class);
         $result = $analyzer->analyzeClass(UserCollection::class)->result();
 
         $resourceResponse = app(ResourceAnalyzer::class)->buildResourceResponse($result->name());
         expect($resourceResponse)->not->toBeNull();
-        expect($resourceResponse->isCollection)->toBeTrue();
+        expect($resourceResponse->isCollection)->toBeFalse();
     });
 
     it('builds ResourceResponse for external use', function () {

--- a/tests/Unit/Analyzer/ResourceAnalyzerTest.php
+++ b/tests/Unit/Analyzer/ResourceAnalyzerTest.php
@@ -3,6 +3,9 @@
 use App\Http\Resources\ChildApiResource;
 use App\Http\Resources\ConditionalLabelResource;
 use App\Http\Resources\ConditionalShapeResource;
+use App\Http\Resources\CustomAttributesCollection;
+use App\Http\Resources\CustomPayloadCollection;
+use App\Http\Resources\CustomResolveResource;
 use App\Http\Resources\CustomWrapResource;
 use App\Http\Resources\PlainLabelResource;
 use App\Http\Resources\PostResource;
@@ -12,10 +15,12 @@ use App\Http\Resources\UserResource;
 use App\Http\Resources\WhenLookupResource;
 use App\Models\Tag;
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Laravel\Surveyor\Analyzer\AnalyzedCache;
 use Laravel\Surveyor\Analyzer\Analyzer;
 use Laravel\Surveyor\Analyzer\ResourceAnalyzer;
 use Laravel\Surveyor\Types\ArrayType;
+use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 use Laravel\Surveyor\Types\Entities\ResourceResponse;
 use Laravel\Surveyor\Types\StringType;
 use Laravel\Surveyor\Types\Type;
@@ -73,36 +78,11 @@ class ResourceController
         'resource collection' => ['ConditionalShapeResource::collection([])->resolve($request)', true],
     ]);
 
-    it('respects a resource that overrides resolve instead of returning its toArray shape', function () {
+    it('respects custom resource and collection resolution', function (string $expression, TypeContract $expected, Closure $resolve, array $expectedData) {
         $fixture = createPhpFixture('
 namespace App\\Test;
 
-use App\\Http\\Resources\\CustomResolveResource;
-
-class ResourceController
-{
-    public function index()
-    {
-        return (new CustomResolveResource(null))->resolve();
-    }
-}');
-
-        try {
-            $result = app(Analyzer::class)->analyze($fixture)->result();
-
-            expect($result->getMethod('index')->returnType())->toEqual(Type::array(['custom' => Type::int()]));
-        } finally {
-            unlink($fixture);
-        }
-    });
-
-    it('resolves the collection implementation rather than the collected resource override', function (bool $customPayload) {
-        $expression = $customPayload
-            ? '(new CustomPayloadCollection([]))->resolve()'
-            : 'CustomResolveResource::collection([])->resolve()';
-        $fixture = createPhpFixture('
-namespace App\\Test;
-
+use App\\Http\\Resources\\CustomAttributesCollection;
 use App\\Http\\Resources\\CustomPayloadCollection;
 use App\\Http\\Resources\\CustomResolveResource;
 
@@ -115,15 +95,104 @@ class ResourceController
 }');
 
         try {
+            expect($resolve())->toBe($expectedData);
+
             $result = app(Analyzer::class)->analyze($fixture)->result();
 
-            expect($result->getMethod('index')->returnType())->toEqual($customPayload
-                ? Type::array(['count' => Type::int(42)])
-                : Type::arrayShape(Type::union(Type::int(), Type::string()), Type::array(['name' => Type::string('Ada')])));
+            expect($result->getMethod('index')->returnType())->toEqual($expected);
         } finally {
             unlink($fixture);
         }
-    })->with([true, false]);
+    })->with([
+        'overridden resolve' => [
+            '(new CustomResolveResource(null))->resolve()',
+            fn () => Type::array(['custom' => Type::int()]),
+            fn () => (new CustomResolveResource(null))->resolve(),
+            ['custom' => 42],
+        ],
+        'custom collection payload' => [
+            '(new CustomPayloadCollection([null]))->resolve()',
+            fn () => Type::array(['count' => Type::int(42)]),
+            fn () => (new CustomPayloadCollection([null]))->resolve(Request::create('/')),
+            ['count' => 42],
+        ],
+        'custom collection attributes' => [
+            '(new CustomAttributesCollection([null]))->resolve()',
+            fn () => Type::array(['attributes' => Type::int(42)]),
+            fn () => (new CustomAttributesCollection([null]))->resolve(Request::create('/')),
+            ['attributes' => 42],
+        ],
+        'collected resource override' => [
+            'CustomResolveResource::collection([null])->resolve()',
+            fn () => Type::arrayShape(Type::union(Type::int(), Type::string()), Type::array(['custom' => Type::int(42)])),
+            fn () => CustomResolveResource::collection([null])->resolve(Request::create('/')),
+            [['custom' => 42]],
+        ],
+    ]);
+
+    it('uses the effective resolution method without guessing inherited or property-backed data', function (string $parent, string $override, bool $analyzed) {
+        $class = 'ResolutionResource'.md5($parent.$override);
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use Illuminate\\Http\\Request;
+
+class '.$class.' extends \\'.$parent.'
+{
+    public function toArray(Request $request): array
+    {
+        return ["legacy" => 1];
+    }
+
+    '.$override.'
+}');
+
+        $resource = 'App\\Test\\'.$class;
+        $caller = createPhpFixture('
+class ResourceController
+{
+    public function index()
+    {
+        return \\'.$resource.'::collection([null])->resolve();
+    }
+}');
+
+        try {
+            require $fixture;
+
+            expect($resource::collection([null])->resolve(Request::create('/')))->toBe([['custom' => 42]]);
+
+            $response = app(ResourceAnalyzer::class)->buildResourceResponse($resource);
+
+            expect($response?->data)->toEqual($analyzed ? Type::array(['custom' => Type::int(42)]) : null);
+
+            $result = app(Analyzer::class)->analyze($caller)->result();
+
+            expect($result->getMethod('index')->returnType())->toEqual($analyzed
+                ? Type::arrayShape(Type::union(Type::int(), Type::string()), Type::array(['custom' => Type::int(42)]))
+                : Type::array([]));
+        } finally {
+            unlink($caller);
+            unlink($fixture);
+        }
+    })->with([
+        'resolveResourceData override' => [
+            JsonResource::class,
+            'public function resolveResourceData(Request $request): array { return ["custom" => 42]; }',
+            true,
+        ],
+        'toAttributes override' => [
+            JsonResource::class,
+            'public function toAttributes(Request $request): array { return ["custom" => 42]; }',
+            true,
+        ],
+        'attributes property' => [
+            JsonResource::class,
+            'public array $attributes = ["custom" => 42];',
+            false,
+        ],
+        'inherited resolve override' => [CustomResolveResource::class, '', false],
+    ]);
 
     it('preserves every toArray return shape for resources and collections', function (bool $isCollection) {
         $response = app(ResourceAnalyzer::class)->buildResourceResponse(ConditionalShapeResource::class, $isCollection);

--- a/tests/Unit/Resolvers/InertiaStaticCallTest.php
+++ b/tests/Unit/Resolvers/InertiaStaticCallTest.php
@@ -6,8 +6,10 @@ use Laravel\Surveyor\Analyzer\Analyzer;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 use Laravel\Surveyor\Types\Entities\InertiaRender;
+use Laravel\Surveyor\Types\Entities\ResourceResponse;
 use Laravel\Surveyor\Types\IntType;
 use Laravel\Surveyor\Types\StringType;
+use Laravel\Surveyor\Types\Type;
 use Laravel\Surveyor\Types\UnionType;
 
 uses()->group('integration');
@@ -38,6 +40,46 @@ function findInertiaRender(TypeContract $type): ?InertiaRender
 }
 
 describe('Inertia special prop types', function () {
+    it('preserves the resource collection payload of Inertia::scroll()', function (string $value) {
+        $fixture = createPhpFixture('
+namespace App\\Test;
+
+use Inertia\\Inertia;
+use App\\Models\\Post;
+use App\\Http\\Resources\\ConditionalShapeResource;
+
+class DashboardController
+{
+    public function index()
+    {
+        return Inertia::render(\'Dashboard\', [
+            \'posts\' => Inertia::scroll('.$value.'),
+        ]);
+    }
+}');
+
+        try {
+            $result = app(Analyzer::class)->analyze($fixture)->result();
+            $render = findInertiaRender($result->getMethod('index')->returnType());
+            $posts = $render->data->value['posts'];
+
+            expect($posts)->toBeInstanceOf(ResourceResponse::class);
+            expect($posts->isCollection)->toBeTrue();
+            expect($posts->wrap)->toBe('data');
+            expect($posts->isOptional())->toBeFalse();
+            expect($posts->data)->toEqual(Type::union(
+                Type::array(['id' => Type::int(1), 'name' => Type::string('Ada')]),
+                Type::array(['id' => Type::int(1)]),
+            ));
+        } finally {
+            unlink($fixture);
+        }
+    })->with([
+        'arrow function' => ['fn () => ConditionalShapeResource::collection(Post::simplePaginate(15))'],
+        'closure' => ['function () { return ConditionalShapeResource::collection(Post::simplePaginate(15)); }'],
+        'direct value' => ['ConditionalShapeResource::collection(Post::simplePaginate(15))'],
+    ]);
+
     it('resolves Inertia::defer() to the callback return type', function () {
         $fixture = createPhpFixture('
 namespace App\\Test;

--- a/tests/Unit/Resolvers/ResourceMethodCallTest.php
+++ b/tests/Unit/Resolvers/ResourceMethodCallTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Http\Resources\MethodCallResource;
+use App\Support\ResourceMethodCalls;
+use Laravel\Surveyor\Analyzer\AnalyzedCache;
+use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Types\Entities\ResourceResponse;
+
+uses()->group('integration');
+
+beforeEach(fn () => AnalyzedCache::clear());
+afterEach(fn () => AnalyzedCache::clear());
+
+it('preserves a resource collection shape through a method call', function (string $method) {
+    $type = app(Analyzer::class)->analyzeClass(ResourceMethodCalls::class)->result()->getMethod($method)->returnType();
+
+    expect($type)->toBeInstanceOf(ResourceResponse::class)
+        ->and($type->resourceClass)->toBe(MethodCallResource::class)
+        ->and($type->isCollection)->toBeTrue()
+        ->and($type->data->keys())->toBe(['id', 'label']);
+})->with(['before', 'after', 'external', 'chained', 'staticCall', 'recursiveCall']);
+
+it('preserves resource collection shapes within an array returned by a method', function () {
+    $type = app(Analyzer::class)->analyzeClass(ResourceMethodCalls::class)->result()->getMethod('groups')->returnType();
+
+    expect($type->value['items'])->toBeInstanceOf(ResourceResponse::class)
+        ->and($type->value['items']->resourceClass)->toBe(MethodCallResource::class);
+});
+
+it('preserves a nullable resource collection returned by a method', function () {
+    $type = app(Analyzer::class)->analyzeClass(ResourceMethodCalls::class)->result()->getMethod('nullableCall')->returnType();
+
+    expect($type)->toBeInstanceOf(ResourceResponse::class)
+        ->and($type->isCollection)->toBeTrue()
+        ->and($type->isNullable())->toBeTrue()
+        ->and($type->data->keys())->toBe(['id', 'label']);
+});

--- a/tests/Unit/Resolvers/ResourceMethodCallTest.php
+++ b/tests/Unit/Resolvers/ResourceMethodCallTest.php
@@ -1,10 +1,14 @@
 <?php
 
+use App\Http\Resources\CustomPayloadCollection;
 use App\Http\Resources\MethodCallResource;
 use App\Support\ResourceMethodCalls;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Laravel\Surveyor\Analyzer\AnalyzedCache;
 use Laravel\Surveyor\Analyzer\Analyzer;
 use Laravel\Surveyor\Types\Entities\ResourceResponse;
+use Laravel\Surveyor\Types\Type;
 
 uses()->group('integration');
 
@@ -19,6 +23,27 @@ it('preserves a resource collection shape through a method call', function (stri
         ->and($type->isCollection)->toBeTrue()
         ->and($type->data->keys())->toBe(['id', 'label']);
 })->with(['before', 'after', 'external', 'chained', 'staticCall', 'recursiveCall']);
+
+it('preserves the anonymous receiver when collecting named collections through methods', function (string $method) {
+    $resource = (new ResourceMethodCalls)->{$method}();
+
+    expect($resource)->toBeInstanceOf(AnonymousResourceCollection::class)
+        ->and($resource->resolve(Request::create('/')))->toBe([['count' => 42]]);
+
+    $type = app(Analyzer::class)->analyzeClass(ResourceMethodCalls::class)->result()->getMethod($method)->returnType();
+
+    expect($type)->toBeInstanceOf(ResourceResponse::class)
+        ->and($type->resolved())->toBe(AnonymousResourceCollection::class)
+        ->and($type->resourceClass)->toBe(CustomPayloadCollection::class)
+        ->and($type->isCollection)->toBeTrue()
+        ->and($type->data)->toEqual(Type::array(['count' => Type::int(42)]));
+})->with(['collectedNamed', 'collectedNamedCall', 'collectedNamedFluent']);
+
+it('resolves a collected named payload after a fluent method call', function () {
+    $type = app(Analyzer::class)->analyzeClass(ResourceMethodCalls::class)->result()->getMethod('collectedNamedResolved')->returnType();
+
+    expect($type)->toEqual(Type::arrayShape(Type::union(Type::int(), Type::string()), Type::array(['count' => Type::int(42)])));
+});
 
 it('preserves resource collection shapes within an array returned by a method', function () {
     $type = app(Analyzer::class)->analyzeClass(ResourceMethodCalls::class)->result()->getMethod('groups')->returnType();

--- a/tests/Unit/Resolvers/ResourceMethodCallTest.php
+++ b/tests/Unit/Resolvers/ResourceMethodCallTest.php
@@ -35,3 +35,13 @@ it('preserves a nullable resource collection returned by a method', function () 
         ->and($type->isNullable())->toBeTrue()
         ->and($type->data->keys())->toBe(['id', 'label']);
 });
+
+it('preserves return branches without a resource alongside resource payloads', function () {
+    $type = app(Analyzer::class)->analyzeClass(ResourceMethodCalls::class)->result()->getMethod('conditionalGroupsCall')->returnType();
+
+    expect($type->keys())->toBe(['items', 'error']);
+    expect($type->value['items'])->toBeInstanceOf(ResourceResponse::class)
+        ->and($type->value['items']->isOptional())->toBeTrue();
+    expect($type->value['error']->value)->toBe('unavailable')
+        ->and($type->value['error']->isOptional())->toBeTrue();
+});

--- a/tests/Unit/Types/UnionTypeTest.php
+++ b/tests/Unit/Types/UnionTypeTest.php
@@ -1,6 +1,10 @@
 <?php
 
+use App\Http\Resources\CustomPayloadCollection;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Laravel\Surveyor\Types\ArrayType;
+use Laravel\Surveyor\Types\ClassType;
+use Laravel\Surveyor\Types\Entities\ResourceResponse;
 use Laravel\Surveyor\Types\IntType;
 use Laravel\Surveyor\Types\StringType;
 use Laravel\Surveyor\Types\Type;
@@ -15,6 +19,13 @@ describe('UnionType', function () {
         expect($union->types)->toHaveCount(2);
         expect($union->types[0])->toBeInstanceOf(StringType::class);
         expect($union->types[1])->toBeInstanceOf(IntType::class);
+    });
+
+    it('preserves anonymous collections alongside named resource collections', function () {
+        $named = new ResourceResponse(CustomPayloadCollection::class, Type::array(['count' => Type::int(42)]), isCollection: true);
+        $anonymous = new ClassType(AnonymousResourceCollection::class);
+
+        expect(Type::union($named, $anonymous))->toEqual(new UnionType([$named, $anonymous]));
     });
 
     it('provides unique id based on types', function () {

--- a/tests/Unit/Types/UnionTypeTest.php
+++ b/tests/Unit/Types/UnionTypeTest.php
@@ -68,5 +68,6 @@ describe('UnionType', function () {
         expect($collapsed)->toBeInstanceOf(ArrayType::class);
         expect($collapsed->value['name']->isOptional())->toBeFalse();
         expect($collapsed->value['age']->isOptional())->toBeTrue();
+        expect($array2->value['age']->isOptional())->toBeFalse();
     });
 });

--- a/workbench/app/Http/Resources/ConditionalShapeResource.php
+++ b/workbench/app/Http/Resources/ConditionalShapeResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ConditionalShapeResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        if ($request->boolean('expanded')) {
+            return ['id' => 1, 'name' => 'Ada'];
+        }
+
+        return ['id' => 1];
+    }
+}

--- a/workbench/app/Http/Resources/CustomAttributesCollection.php
+++ b/workbench/app/Http/Resources/CustomAttributesCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class CustomAttributesCollection extends ResourceCollection
+{
+    public $collects = ConditionalShapeResource::class;
+
+    public function toAttributes(Request $request): array
+    {
+        return ['attributes' => 42];
+    }
+}

--- a/workbench/app/Http/Resources/CustomPayloadCollection.php
+++ b/workbench/app/Http/Resources/CustomPayloadCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class CustomPayloadCollection extends ResourceCollection
+{
+    public $collects = ConditionalShapeResource::class;
+
+    public function toArray(Request $request): array
+    {
+        return ['count' => 42];
+    }
+}

--- a/workbench/app/Http/Resources/CustomResolveResource.php
+++ b/workbench/app/Http/Resources/CustomResolveResource.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CustomResolveResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return ['name' => 'Ada'];
+    }
+
+    /** @return array{custom: int} */
+    public function resolve($request = null): array
+    {
+        return ['custom' => 42];
+    }
+}

--- a/workbench/app/Http/Resources/MappedResourceCollection.php
+++ b/workbench/app/Http/Resources/MappedResourceCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class MappedResourceCollection extends ResourceCollection
+{
+    public $collects = MethodCallResource::class;
+
+    public function toArray(Request $request): array
+    {
+        $start = $this->additional['start'] ?? null;
+
+        return $this->collection?->map(function ($resource) use ($start) {
+            return (new MethodCallResource($resource))->additional(['start' => $start]);
+        })->toArray() ?? [];
+    }
+}

--- a/workbench/app/Http/Resources/MethodCallCollection.php
+++ b/workbench/app/Http/Resources/MethodCallCollection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class MethodCallCollection extends ResourceCollection
+{
+    //
+}

--- a/workbench/app/Http/Resources/MethodCallResource.php
+++ b/workbench/app/Http/Resources/MethodCallResource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class MethodCallResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return ['id' => 1, 'label' => 'Example'];
+    }
+}

--- a/workbench/app/Support/ResourceMethodCalls.php
+++ b/workbench/app/Support/ResourceMethodCalls.php
@@ -74,4 +74,18 @@ class ResourceMethodCalls
     {
         return $provider->groups();
     }
+
+    public function conditionalGroups(bool $available): array
+    {
+        if ($available) {
+            return ['items' => MethodCallResource::collection([])];
+        }
+
+        return ['error' => 'unavailable'];
+    }
+
+    public function conditionalGroupsCall()
+    {
+        return $this->conditionalGroups(false);
+    }
 }

--- a/workbench/app/Support/ResourceMethodCalls.php
+++ b/workbench/app/Support/ResourceMethodCalls.php
@@ -2,6 +2,7 @@
 
 namespace App\Support;
 
+use App\Http\Resources\CustomPayloadCollection;
 use App\Http\Resources\MethodCallResource;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
@@ -40,6 +41,26 @@ class ResourceMethodCalls
     public function collection(): AnonymousResourceCollection
     {
         return MethodCallResource::collection([]);
+    }
+
+    public function collectedNamed(): AnonymousResourceCollection
+    {
+        return CustomPayloadCollection::collection([[null]]);
+    }
+
+    public function collectedNamedCall()
+    {
+        return $this->collectedNamed();
+    }
+
+    public function collectedNamedFluent()
+    {
+        return $this->collectedNamed()->additional(['source' => 'test']);
+    }
+
+    public function collectedNamedResolved()
+    {
+        return $this->collectedNamed()->additional(['source' => 'test'])->resolve();
     }
 
     public function recursive(bool $repeat): AnonymousResourceCollection

--- a/workbench/app/Support/ResourceMethodCalls.php
+++ b/workbench/app/Support/ResourceMethodCalls.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Support;
+
+use App\Http\Resources\MethodCallResource;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class ResourceMethodCalls
+{
+    public function before()
+    {
+        return $this->collection();
+    }
+
+    public function chained()
+    {
+        return $this->forward();
+    }
+
+    public function forward(): AnonymousResourceCollection
+    {
+        return $this->collection();
+    }
+
+    public function staticCall()
+    {
+        return self::collection();
+    }
+
+    public function recursiveCall()
+    {
+        return $this->recursive(false);
+    }
+
+    public function nullableCall()
+    {
+        return $this->nullable(false);
+    }
+
+    public function collection(): AnonymousResourceCollection
+    {
+        return MethodCallResource::collection([]);
+    }
+
+    public function recursive(bool $repeat): AnonymousResourceCollection
+    {
+        if ($repeat) {
+            return $this->recursive(false);
+        }
+
+        return MethodCallResource::collection([]);
+    }
+
+    public function nullable(bool $include): ?AnonymousResourceCollection
+    {
+        if (! $include) {
+            return null;
+        }
+
+        return MethodCallResource::collection([]);
+    }
+
+    public function after()
+    {
+        return $this->collection();
+    }
+
+    public function external(ResourceProvider $provider)
+    {
+        return $provider->collection();
+    }
+
+    public function groups(ResourceProvider $provider)
+    {
+        return $provider->groups();
+    }
+}

--- a/workbench/app/Support/ResourceProvider.php
+++ b/workbench/app/Support/ResourceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Support;
+
+use App\Http\Resources\MethodCallResource;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class ResourceProvider
+{
+    public function collection(): AnonymousResourceCollection
+    {
+        return MethodCallResource::collection([]);
+    }
+
+    /** @return array{items: AnonymousResourceCollection} */
+    public function groups(): array
+    {
+        return ['items' => MethodCallResource::collection([])];
+    }
+}


### PR DESCRIPTION
A resource returned through a helper can lose its payload and appear as a PHP class in generated Inertia props. `Inertia::scroll()` and explicit `resolve()` calls have similar gaps. A helper returning either an `items` payload or an `error` payload can also lose the error branch.

Analyze resource-bearing helpers when their bodies have not been visited, restore the caller's scope afterward, and retain the complete return union. Property types are cloned before changing their required state so cached results stay intact.

Collection analysis distinguishes an item shape from a custom method's complete payload. Resolution follows the effective Laravel method, and `::collection()` retains its actual anonymous collection class. This avoids extra array levels and unrelated class branches without guessing what a mapping callback returns. Collection generic inference remains the subject of [#39](https://github.com/laravel/surveyor/pull/39) and [#47](https://github.com/laravel/surveyor/pull/47).

The regression tests include comparisons with native JSON responses. All 422 tests pass on Laravel 12.69.2 and 13.31.0, with two existing skips; PHPStan and Pint pass. The minimum `illuminate/http` version becomes 12.45.2, which introduced the collection behavior in [framework #58302](https://github.com/laravel/framework/pull/58302).

Companion change: [laravel/ranger#56](https://github.com/laravel/ranger/pull/56) preserves these payload types for downstream generators.
